### PR TITLE
BitArchiveInfo with encrypted archives

### DIFF
--- a/include/bitarchivehandler.hpp
+++ b/include/bitarchivehandler.hpp
@@ -182,7 +182,7 @@ namespace bit7z {
             const Bit7zLibrary& mLibrary;
             wstring mPassword;
 
-            explicit BitArchiveHandler( const Bit7zLibrary& lib );
+            explicit BitArchiveHandler( const Bit7zLibrary& lib, const wstring& password = L"");
 
             virtual ~BitArchiveHandler() = 0;
 

--- a/include/bitarchivehandler.hpp
+++ b/include/bitarchivehandler.hpp
@@ -182,7 +182,7 @@ namespace bit7z {
             const Bit7zLibrary& mLibrary;
             wstring mPassword;
 
-            explicit BitArchiveHandler( const Bit7zLibrary& lib, const wstring& password = L"");
+            explicit BitArchiveHandler( const Bit7zLibrary& lib, const wstring& password = L"" );
 
             virtual ~BitArchiveHandler() = 0;
 

--- a/include/bitarchiveinfo.hpp
+++ b/include/bitarchiveinfo.hpp
@@ -48,7 +48,8 @@ namespace bit7z {
              */
             BitArchiveInfo( const Bit7zLibrary& lib,
                             const wstring& in_file,
-                            const BitInFormat& format DEFAULT_FORMAT );
+                            const BitInFormat& format DEFAULT_FORMAT,
+                            const wstring& password = L"");
 
             /**
              * @brief Constructs a BitArchiveInfo object, opening the archive in the input buffer.

--- a/include/bitarchiveinfo.hpp
+++ b/include/bitarchiveinfo.hpp
@@ -49,7 +49,7 @@ namespace bit7z {
             BitArchiveInfo( const Bit7zLibrary& lib,
                             const wstring& in_file,
                             const BitInFormat& format DEFAULT_FORMAT,
-                            const wstring& password = L"");
+                            const wstring& password = L"" );
 
             /**
              * @brief Constructs a BitArchiveInfo object, opening the archive in the input buffer.
@@ -65,7 +65,8 @@ namespace bit7z {
              */
             BitArchiveInfo( const Bit7zLibrary& lib,
                             const vector< byte_t >& in_buffer,
-                            const BitInFormat& format DEFAULT_FORMAT );
+                            const BitInFormat& format DEFAULT_FORMAT,
+                            const wstring& password = L"" );
 
             /**
              * @brief Constructs a BitArchiveInfo object, opening the archive from the standard input stream.
@@ -81,7 +82,8 @@ namespace bit7z {
              */
             BitArchiveInfo( const Bit7zLibrary& lib,
                             std::istream& in_stream,
-                            const BitInFormat& format DEFAULT_FORMAT );
+                            const BitInFormat& format DEFAULT_FORMAT,
+                            const wstring& password = L"" );
 
             /**
              * @brief BitArchiveInfo destructor.

--- a/include/bitarchiveinfo.hpp
+++ b/include/bitarchiveinfo.hpp
@@ -45,6 +45,7 @@ namespace bit7z {
              * @param lib       the 7z library used.
              * @param in_file   the input archive file path.
              * @param format    the input archive format.
+             * @param password  the password needed to open the input archive.
              */
             BitArchiveInfo( const Bit7zLibrary& lib,
                             const wstring& in_file,
@@ -62,6 +63,7 @@ namespace bit7z {
              * @param lib       the 7z library used.
              * @param in_buffer the input buffer containing the archive.
              * @param format    the input archive format.
+             * @param password  the password needed to open the input archive.
              */
             BitArchiveInfo( const Bit7zLibrary& lib,
                             const vector< byte_t >& in_buffer,
@@ -79,6 +81,7 @@ namespace bit7z {
              * @param lib       the 7z library used.
              * @param in_stream the standard input stream of the archive.
              * @param format    the input archive format.
+             * @param password  the password needed to open the input archive.
              */
             BitArchiveInfo( const Bit7zLibrary& lib,
                             std::istream& in_stream,

--- a/include/bitarchiveopener.hpp
+++ b/include/bitarchiveopener.hpp
@@ -52,7 +52,7 @@ namespace bit7z {
         protected:
             const BitInFormat& mFormat;
 
-            BitArchiveOpener( const Bit7zLibrary& lib, const BitInFormat& format );
+            BitArchiveOpener( const Bit7zLibrary& lib, const BitInFormat& format, const wstring& password = L"");
 
             virtual ~BitArchiveOpener() override = 0;
 

--- a/include/bitarchiveopener.hpp
+++ b/include/bitarchiveopener.hpp
@@ -52,7 +52,7 @@ namespace bit7z {
         protected:
             const BitInFormat& mFormat;
 
-            BitArchiveOpener( const Bit7zLibrary& lib, const BitInFormat& format, const wstring& password = L"");
+            BitArchiveOpener( const Bit7zLibrary& lib, const BitInFormat& format, const wstring& password = L"" );
 
             virtual ~BitArchiveOpener() override = 0;
 

--- a/src/bitarchivehandler.cpp
+++ b/src/bitarchivehandler.cpp
@@ -24,7 +24,7 @@
 using namespace bit7z;
 using std::wstring;
 
-BitArchiveHandler::BitArchiveHandler( const Bit7zLibrary& lib ) : mLibrary( lib ), mPassword( L"" ) {}
+BitArchiveHandler::BitArchiveHandler( const Bit7zLibrary& lib, const wstring& password) : mLibrary( lib ), mPassword(password) {}
 
 const Bit7zLibrary& BitArchiveHandler::library() const {
     return mLibrary;

--- a/src/bitarchivehandler.cpp
+++ b/src/bitarchivehandler.cpp
@@ -24,7 +24,7 @@
 using namespace bit7z;
 using std::wstring;
 
-BitArchiveHandler::BitArchiveHandler( const Bit7zLibrary& lib, const wstring& password) : mLibrary( lib ), mPassword(password) {}
+BitArchiveHandler::BitArchiveHandler( const Bit7zLibrary& lib, const wstring& password ) : mLibrary( lib ), mPassword( password ) {}
 
 const Bit7zLibrary& BitArchiveHandler::library() const {
     return mLibrary;

--- a/src/bitarchiveinfo.cpp
+++ b/src/bitarchiveinfo.cpp
@@ -28,8 +28,8 @@
 
 using namespace bit7z;
 
-BitArchiveInfo::BitArchiveInfo( const Bit7zLibrary& lib, const wstring& in_file, const BitInFormat& format )
-    : BitArchiveOpener( lib, format ), BitInputArchive( *this, in_file ) {}
+BitArchiveInfo::BitArchiveInfo( const Bit7zLibrary& lib, const wstring& in_file, const BitInFormat& format, const wstring& password)
+    : BitArchiveOpener( lib, format, password ), BitInputArchive( *this, in_file ) {}
 
 BitArchiveInfo::BitArchiveInfo( const Bit7zLibrary& lib, const vector< byte_t >& in_buffer, const BitInFormat& format )
     : BitArchiveOpener( lib, format ), BitInputArchive( *this, in_buffer ) {}

--- a/src/bitarchiveinfo.cpp
+++ b/src/bitarchiveinfo.cpp
@@ -28,14 +28,14 @@
 
 using namespace bit7z;
 
-BitArchiveInfo::BitArchiveInfo( const Bit7zLibrary& lib, const wstring& in_file, const BitInFormat& format, const wstring& password)
+BitArchiveInfo::BitArchiveInfo( const Bit7zLibrary& lib, const wstring& in_file, const BitInFormat& format, const wstring& password )
     : BitArchiveOpener( lib, format, password ), BitInputArchive( *this, in_file ) {}
 
-BitArchiveInfo::BitArchiveInfo( const Bit7zLibrary& lib, const vector< byte_t >& in_buffer, const BitInFormat& format )
-    : BitArchiveOpener( lib, format ), BitInputArchive( *this, in_buffer ) {}
+BitArchiveInfo::BitArchiveInfo( const Bit7zLibrary& lib, const vector< byte_t >& in_buffer, const BitInFormat& format, const wstring& password )
+    : BitArchiveOpener( lib, format, password ), BitInputArchive( *this, in_buffer ) {}
 
-BitArchiveInfo::BitArchiveInfo( const Bit7zLibrary& lib, std::istream& in_stream, const BitInFormat& format )
-    : BitArchiveOpener( lib, format ), BitInputArchive( *this, in_stream ) {}
+BitArchiveInfo::BitArchiveInfo( const Bit7zLibrary& lib, std::istream& in_stream, const BitInFormat& format, const wstring& password )
+    : BitArchiveOpener( lib, format, password ), BitInputArchive( *this, in_stream ) {}
 
 BitArchiveInfo::~BitArchiveInfo() {}
 

--- a/src/bitarchiveopener.cpp
+++ b/src/bitarchiveopener.cpp
@@ -34,8 +34,8 @@ using namespace bit7z;
 
 CONSTEXPR auto kCannotExtractFolderToBuffer = "Cannot extract a folder to a buffer";
 
-BitArchiveOpener::BitArchiveOpener( const Bit7zLibrary& lib, const BitInFormat& format, const wstring& password)
-    : BitArchiveHandler( lib, password), mFormat( format ) {}
+BitArchiveOpener::BitArchiveOpener( const Bit7zLibrary& lib, const BitInFormat& format, const wstring& password )
+    : BitArchiveHandler( lib, password ), mFormat( format ) {}
 
 BitArchiveOpener::~BitArchiveOpener() {}
 

--- a/src/bitarchiveopener.cpp
+++ b/src/bitarchiveopener.cpp
@@ -34,8 +34,8 @@ using namespace bit7z;
 
 CONSTEXPR auto kCannotExtractFolderToBuffer = "Cannot extract a folder to a buffer";
 
-BitArchiveOpener::BitArchiveOpener( const Bit7zLibrary& lib, const BitInFormat& format )
-    : BitArchiveHandler( lib ), mFormat( format ) {}
+BitArchiveOpener::BitArchiveOpener( const Bit7zLibrary& lib, const BitInFormat& format, const wstring& password)
+    : BitArchiveHandler( lib, password), mFormat( format ) {}
 
 BitArchiveOpener::~BitArchiveOpener() {}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
BitArchiveInfo did not work with encrypted archives since opening the file was done in the constructors, there was no way to define a password query function or pass the password down the constructor line.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
<!-- TODO: - [ ] I have read the **CONTRIBUTING** document. -->