### PR TITLE
Fixed CMake target_include_directories scope

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,9 +149,12 @@ if(BIT7Z_REGEX_MATCHING)
 endif()
 
 # includes
-target_include_directories(${TARGET_NAME} PRIVATE 
-    ${PROJECT_SOURCE_DIR}/include/
-    ${PROJECT_SOURCE_DIR}/lib/7zSDK/CPP/
+target_include_directories(${TARGET_NAME} PUBLIC
+        ${PROJECT_SOURCE_DIR}/include/
+)
+
+target_include_directories(${TARGET_NAME} PRIVATE
+        ${PROJECT_SOURCE_DIR}/lib/7zSDK/CPP/
 )
 
 # compiler options


### PR DESCRIPTION
# Fixed CMake target_include_directories

## Description
Divided public and private include directories for target

## Motivation and Context
Library just doesn't include normally in another projects

## How Has This Been Tested?
Included in my project with this simple CMakeLists.txt
```
cmake_minimum_required(VERSION 3.1)
project(uses_bit7z LANGUAGES CXX)

add_subdirectory(bit7z)
add_executable(uses_bit7z main.cpp)
target_link_libraries(uses_bit7z bit7z64)
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
<!-- TODO: - [ ] I have read the **CONTRIBUTING** document. -->