### PR TITLE
BitException::getErrorCode() marked as 'const'

### DIFF
--- a/include/bitexception.hpp
+++ b/include/bitexception.hpp
@@ -78,7 +78,7 @@ namespace bit7z {
             /**
              * @return the HRESULT code associated with the exception object.
              */
-            HRESULT getErrorCode();
+            HRESULT getErrorCode() const;
 
         private:
             HRESULT mErrorCode;

--- a/src/bitexception.cpp
+++ b/src/bitexception.cpp
@@ -45,6 +45,6 @@ BitException::BitException( const wstring& message, HRESULT code )
 BitException::BitException( const wstring& message, DWORD code )
     : runtime_error( ws2s( message ) ), mErrorCode( HRESULT_FROM_WIN32( code ) ) {}
 
-HRESULT BitException::getErrorCode() {
+HRESULT BitException::getErrorCode() const {
     return mErrorCode;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
[`BitException::getErrorCode()`](https://github.com/rikyoz/bit7z/blob/master/include/bitexception.hpp#L81) marked as `const`
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #63 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Build the following code: 
```c++
// main.cpp
#include <bit7zlibrary.hpp>
#include <iostream>
#include <iomanip>

int main {
  try {
    bit7z::Bit7zLibrary lib;
  } catch (const BitException& exc) {
    std::cerr << "Unable to unpack an archive: error " << std::hex << exc.getErrorCode() << std::endl;
  }
  return 0;
}
```
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
<!-- TODO: - [ ] I have read the **CONTRIBUTING** document. -->