### PR TITLE
Use macro instead of function for HRESULT_FROM_WIN32

### DIFF
--- a/src/internal/hresultcategory.cpp
+++ b/src/internal/hresultcategory.cpp
@@ -91,7 +91,7 @@ std::error_condition hresult_category_t::default_error_condition( int error_valu
             // e.g., function not implemented
             return std::make_error_condition( std::errc::function_not_supported );
 #ifdef _WIN32
-        case HRESULT_FROM_WIN32( ERROR_NOT_SUPPORTED ):
+        case __HRESULT_FROM_WIN32( ERROR_NOT_SUPPORTED ):
 #endif
         case E_NOINTERFACE:
             // e.g., function implemented, parameters ok, but the requested functionality is not available.


### PR DESCRIPTION
## Description
Use the double underscore macro instead of the non constexpr function.

## Motivation and Context
It fixes https://github.com/rikyoz/bit7z/issues/129

## How Has This Been Tested?
Tested compilation with MSVC 2017 and 2019

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
