### PR TITLE
Fix missing `std::transform` at 530 line

### DIFF
--- a/src/internal/formatdetect.cpp
+++ b/src/internal/formatdetect.cpp
@@ -12,6 +12,7 @@
 
 #ifdef BIT7Z_AUTO_FORMAT
 
+#include <algorithm>
 #include "internal/formatdetect.hpp"
 
 #if defined(BIT7Z_USE_NATIVE_STRING) && defined(_WIN32)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fix missing of `std::transform` at `src/internal/formatdetect.cpp`. Library doesn't compile with `-DBIT7Z_AUTO_FORMAT` flag.

## Description

Fix missing of `std::transform`

## Motivation and Context

Wanna fix missing of `std::transform`

## How Has This Been Tested?

Just compiled library with `-DBIT7Z_AUTO_FORMAT` flag

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
<!-- TODO: - [X] I have read the **CONTRIBUTING** document. -->