### PR TITLE
[fix] fix-filesystem-include-error

### DIFF
--- a/include/bit7z/bitfs.hpp
+++ b/include/bit7z/bitfs.hpp
@@ -30,12 +30,10 @@ namespace ghc {
 }
 #endif
 
-namespace fs {
 #ifdef BIT7Z_USE_STANDARD_FILESYSTEM
-using namespace std::filesystem;
+namespace fs = std::filesystem;
 #else
-using namespace ghc::filesystem;
+namespace fs = ghc::filesystem;
 #endif
-} // namespace fs
 
 #endif //BITFS_HPP


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
fix-filesystem-include-error

#141 

## Motivation and Context
fs is a common acronym for filesystem namespaces that may be defined repeatedly across multiple header files,use aliases instead of explicitly declaring namespaces to avoid namespace redefinition error.

## How Has This Been Tested?
before:

```log
Error	C2757	'fs': a symbol with this name already exists and therefore this name cannot be used as a namespace name	
Error	C1907	unable to recover from previous error(s); stopping compilation
```
after:
build success.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [&check;] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [&check;] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
<!-- TODO: - [x ] I have read the **CONTRIBUTING** document. -->