### PR TITLE
Fix special characters causing file creation failure

### DIFF
--- a/cmake/BuildOptions.cmake
+++ b/cmake/BuildOptions.cmake
@@ -53,4 +53,11 @@ if( WIN32 )
     if( BIT7Z_AUTO_PREFIX_LONG_PATHS )
         target_compile_definitions( ${LIB_TARGET} PUBLIC BIT7Z_AUTO_PREFIX_LONG_PATHS )
     endif()
+
+    option( BIT7Z_PATH_SANITIZATION "Enable or disable path sanitization when extracting archives \
+containing files with invalid Windows names" )
+    message( STATUS "Path sanitization: ${BIT7Z_PATH_SANITIZATION}" )
+    if( BIT7Z_PATH_SANITIZATION )
+        target_compile_definitions( ${LIB_TARGET} PUBLIC BIT7Z_PATH_SANITIZATION )
+    endif()
 endif()

--- a/src/internal/fileextractcallback.cpp
+++ b/src/internal/fileextractcallback.cpp
@@ -112,7 +112,7 @@ inline auto sanitize_path_component( wstring component ) -> wstring {
  * @return the sanitized path, where illegal characters are replaced with the '_' character.
  */
 inline auto sanitize_path( const fs::path& path ) -> fs::path {
-    fs::path sanitized_path;
+    fs::path sanitized_path = path.root_name();
     for( const auto& path_component : path ) {
         sanitized_path /= sanitize_path_component( path_component.native() );
     }

--- a/src/internal/fileextractcallback.cpp
+++ b/src/internal/fileextractcallback.cpp
@@ -72,13 +72,12 @@ fs::path FileExtractCallback::getCurrentItemPath() const {
     return filePath;
 }
 
-std::wstring CharacterStandard(const std::wstring& src)
-{
-	std::wstring destChar = src;
-	//Define Rules
-	std::wregex illegalCharRegex(L"[<>:\"/|?*]");
-	//Replacing illegal characters with underscores using regular expressions
-    destChar = std::regex_replace(destChar, illegalCharRegex, L"_");
+std::wstring CharacterStandard( const std::wstring& src ) {
+    std::wstring destChar = src;
+    //Define Rules
+    std::wregex illegalCharRegex( L"[<>:\"/|?*]" );
+    //Replacing illegal characters with underscores using regular expressions
+    destChar = std::regex_replace( destChar, illegalCharRegex, L"_" );
 	return destChar.c_str();
 }
 
@@ -86,8 +85,8 @@ HRESULT FileExtractCallback::getOutStream( uint32_t index, ISequentialOutStream*
     mCurrentItem.loadItemInfo( inputArchive(), index );
 
     auto filePath = getCurrentItemPath();
-	//Normalize String
-	filePath = CharacterStandard(filePath.wstring());
+    // Normalize String
+    filePath = CharacterStandard( filePath.wstring() );
     mFilePathOnDisk = mDirectoryPath / filePath;
 
 #if defined( _WIN32 ) && defined( BIT7Z_AUTO_PREFIX_LONG_PATHS )

--- a/src/internal/fileextractcallback.cpp
+++ b/src/internal/fileextractcallback.cpp
@@ -16,7 +16,7 @@
 #include "internal/fsutil.hpp"
 #include "internal/util.hpp"
 
-#ifdef _WIN32
+#if defined( _WIN32 ) && defined( BIT7Z_PATH_SANITIZATION )
 #include <cwctype> // for iswdigit
 #endif
 
@@ -75,7 +75,7 @@ fs::path FileExtractCallback::getCurrentItemPath() const {
     return filePath;
 }
 
-#ifdef _WIN32
+#if defined( _WIN32 ) && defined( BIT7Z_PATH_SANITIZATION )
 inline auto is_windows_reserved_name( const wstring& component ) -> bool {
     // Reserved file names that can't be used on Windows: CON, PRN, AUX, and NUL.
     if ( component == L"CON" || component == L"PRN" || component == L"AUX" || component == L"NUL" ) {
@@ -124,7 +124,7 @@ HRESULT FileExtractCallback::getOutStream( uint32_t index, ISequentialOutStream*
     mCurrentItem.loadItemInfo( inputArchive(), index );
 
     auto filePath = getCurrentItemPath();
-#ifdef _WIN32
+#if defined( _WIN32 ) && defined( BIT7Z_PATH_SANITIZATION )
     filePath = sanitize_path( filePath );
 #endif
     mFilePathOnDisk = mDirectoryPath / filePath;

--- a/src/internal/fileextractcallback.cpp
+++ b/src/internal/fileextractcallback.cpp
@@ -16,9 +16,6 @@
 #include "internal/fsutil.hpp"
 #include "internal/util.hpp"
 
-#if defined( _WIN32 ) && defined( BIT7Z_PATH_SANITIZATION )
-#include <cwctype> // for iswdigit
-#endif
 
 using namespace std;
 using namespace NWindows;
@@ -75,59 +72,12 @@ fs::path FileExtractCallback::getCurrentItemPath() const {
     return filePath;
 }
 
-#if defined( _WIN32 ) && defined( BIT7Z_PATH_SANITIZATION )
-inline auto is_windows_reserved_name( const std::wstring& component ) -> bool {
-    // Reserved file names that can't be used on Windows: CON, PRN, AUX, and NUL.
-    if ( component == L"CON" || component == L"PRN" || component == L"AUX" || component == L"NUL" ) {
-        return true;
-    }
-    // Reserved file names that can't be used on Windows:
-    // COM0, COM1, COM2, COM3, COM4, COM5, COM6, COM7, COM8, COM9,
-    // LPT0, LPT1, LPT2, LPT3, LPT4, LPT5, LPT6, LPT7, LPT8, and LPT9.
-    return component.size() == 4 &&
-           ( component.find(L"COM") == 0 || component.find(L"LPT") == 0 ) &&
-           std::iswdigit( component.back() ) != 0;
-}
-
-inline auto sanitize_path_component( std::wstring component ) -> std::wstring {
-    // If the component is a reserved name on Windows, we prepend it with a '_' character.
-    if ( is_windows_reserved_name( component ) ) {
-        component.insert( 0, 1, '_' );
-    }
-
-    // Replacing all reserved characters in the component with the '_' character.
-    std::replace_if( component.begin(), component.end(), []( wchar_t chr ) {
-        constexpr auto last_non_printable_ascii = 31;
-        return chr <= last_non_printable_ascii || chr == L'[' || chr == L'<' || chr == L'>' || chr == L':' ||
-               chr == L'"' || chr == L'/' || chr == L'|' || chr == L'?' || chr == L'*' || chr == L']';
-    }, L'_' );
-    return component;
-}
-
-/**
- * Sanitizes the given file path, removing any eventual Windows illegal character
- * (https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file)
- *
- * @param path The path to be sanitized.
- *
- * @return the sanitized path, where illegal characters are replaced with the '_' character.
- */
-inline auto sanitize_path( const fs::path& path ) -> fs::path {
-    fs::path sanitized_path = path.root_path().make_preferred();
-    for( const auto& path_component : path.relative_path() ) {
-        // cppcheck-suppress useStlAlgorithm
-        sanitized_path /= sanitize_path_component( path_component.wstring() );
-    }
-    return sanitized_path;
-}
-#endif
-
 HRESULT FileExtractCallback::getOutStream( uint32_t index, ISequentialOutStream** outStream ) {
     mCurrentItem.loadItemInfo( inputArchive(), index );
 
     auto filePath = getCurrentItemPath();
 #if defined( _WIN32 ) && defined( BIT7Z_PATH_SANITIZATION )
-    mFilePathOnDisk = mDirectoryPath / sanitize_path( filePath );
+    mFilePathOnDisk = mDirectoryPath / fsutil::sanitize_path( filePath );
 #else
     mFilePathOnDisk = mDirectoryPath / filePath;
 #endif

--- a/src/internal/fileextractcallback.cpp
+++ b/src/internal/fileextractcallback.cpp
@@ -76,7 +76,7 @@ fs::path FileExtractCallback::getCurrentItemPath() const {
 }
 
 #if defined( _WIN32 ) && defined( BIT7Z_PATH_SANITIZATION )
-inline auto is_windows_reserved_name( const wstring& component ) -> bool {
+inline auto is_windows_reserved_name( const std::wstring& component ) -> bool {
     // Reserved file names that can't be used on Windows: CON, PRN, AUX, and NUL.
     if ( component == L"CON" || component == L"PRN" || component == L"AUX" || component == L"NUL" ) {
         return true;
@@ -89,7 +89,7 @@ inline auto is_windows_reserved_name( const wstring& component ) -> bool {
            std::iswdigit( component.back() ) != 0;
 }
 
-inline auto sanitize_path_component( wstring component ) -> wstring {
+inline auto sanitize_path_component( std::wstring component ) -> std::wstring {
     // If the component is a reserved name on Windows, we prepend it with a '_' character.
     if ( is_windows_reserved_name( component ) ) {
         component.insert( 0, 1, '_' );
@@ -103,6 +103,7 @@ inline auto sanitize_path_component( wstring component ) -> wstring {
     }, L'_' );
     return component;
 }
+
 /**
  * Sanitizes the given file path, removing any eventual Windows illegal character
  * (https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file)

--- a/src/internal/fileextractcallback.cpp
+++ b/src/internal/fileextractcallback.cpp
@@ -113,9 +113,9 @@ inline auto sanitize_path_component( std::wstring component ) -> std::wstring {
  * @return the sanitized path, where illegal characters are replaced with the '_' character.
  */
 inline auto sanitize_path( const fs::path& path ) -> fs::path {
-    fs::path sanitized_path = path.root_name();
-    for( const auto& path_component : path ) {
-        sanitized_path /= sanitize_path_component( path_component.native() );
+    fs::path sanitized_path = path.root_path().make_preferred();
+    for( const auto& path_component : path.relative_path() ) {
+        sanitized_path /= sanitize_path_component( path_component.wstring() );
     }
     return sanitized_path;
 }

--- a/src/internal/fileextractcallback.cpp
+++ b/src/internal/fileextractcallback.cpp
@@ -78,7 +78,7 @@ std::wstring CharacterStandard( const std::wstring& src ) {
     std::wregex illegalCharRegex( L"[<>:\"/|?*]" );
     //Replacing illegal characters with underscores using regular expressions
     destChar = std::regex_replace( destChar, illegalCharRegex, L"_" );
-	return destChar.c_str();
+    return destChar;
 }
 
 HRESULT FileExtractCallback::getOutStream( uint32_t index, ISequentialOutStream** outStream ) {

--- a/src/internal/fileextractcallback.cpp
+++ b/src/internal/fileextractcallback.cpp
@@ -77,12 +77,10 @@ fs::path FileExtractCallback::getCurrentItemPath() const {
 
 #ifdef _WIN32
 std::wstring CharacterStandard( const std::wstring& src ) {
-    std::wstring destChar = src;
     //Define Rules
-    std::wregex illegalCharRegex( L"[<>:\"/|?*]" );
+    const std::wregex illegalCharRegex( L"[<>:\"/|?*]" );
     //Replacing illegal characters with underscores using regular expressions
-    destChar = std::regex_replace( destChar, illegalCharRegex, L"_" );
-    return destChar;
+    return std::regex_replace( src, illegalCharRegex, L"_" );
 }
 #endif
 

--- a/src/internal/fileextractcallback.cpp
+++ b/src/internal/fileextractcallback.cpp
@@ -15,6 +15,7 @@
 #include "bitexception.hpp"
 #include "internal/fsutil.hpp"
 #include "internal/util.hpp"
+#include <regex>
 
 using namespace std;
 using namespace NWindows;
@@ -71,10 +72,22 @@ fs::path FileExtractCallback::getCurrentItemPath() const {
     return filePath;
 }
 
+std::wstring CharacterStandard(const std::wstring& src)
+{
+	std::wstring destChar = src;
+	//Define Rules
+	std::wregex illegalCharRegex(L"[<>:\"/|?*]");
+	//Replacing illegal characters with underscores using regular expressions
+    destChar = std::regex_replace(destChar, illegalCharRegex, L"_");
+	return destChar.c_str();
+}
+
 HRESULT FileExtractCallback::getOutStream( uint32_t index, ISequentialOutStream** outStream ) {
     mCurrentItem.loadItemInfo( inputArchive(), index );
 
     auto filePath = getCurrentItemPath();
+	//Normalize String
+	filePath = CharacterStandard(filePath.wstring());
     mFilePathOnDisk = mDirectoryPath / filePath;
 
 #if defined( _WIN32 ) && defined( BIT7Z_AUTO_PREFIX_LONG_PATHS )

--- a/src/internal/fileextractcallback.cpp
+++ b/src/internal/fileextractcallback.cpp
@@ -115,6 +115,7 @@ inline auto sanitize_path_component( std::wstring component ) -> std::wstring {
 inline auto sanitize_path( const fs::path& path ) -> fs::path {
     fs::path sanitized_path = path.root_path().make_preferred();
     for( const auto& path_component : path.relative_path() ) {
+        // cppcheck-suppress useStlAlgorithm
         sanitized_path /= sanitize_path_component( path_component.wstring() );
     }
     return sanitized_path;
@@ -126,9 +127,10 @@ HRESULT FileExtractCallback::getOutStream( uint32_t index, ISequentialOutStream*
 
     auto filePath = getCurrentItemPath();
 #if defined( _WIN32 ) && defined( BIT7Z_PATH_SANITIZATION )
-    filePath = sanitize_path( filePath );
-#endif
+    mFilePathOnDisk = mDirectoryPath / sanitize_path( filePath );
+#else
     mFilePathOnDisk = mDirectoryPath / filePath;
+#endif
 
 #if defined( _WIN32 ) && defined( BIT7Z_AUTO_PREFIX_LONG_PATHS )
     if ( fsutil::should_format_long_path( mFilePathOnDisk ) ) {

--- a/src/internal/fileextractcallback.cpp
+++ b/src/internal/fileextractcallback.cpp
@@ -15,7 +15,10 @@
 #include "bitexception.hpp"
 #include "internal/fsutil.hpp"
 #include "internal/util.hpp"
+
+#ifdef _WIN32
 #include <regex>
+#endif
 
 using namespace std;
 using namespace NWindows;
@@ -72,6 +75,7 @@ fs::path FileExtractCallback::getCurrentItemPath() const {
     return filePath;
 }
 
+#ifdef _WIN32
 std::wstring CharacterStandard( const std::wstring& src ) {
     std::wstring destChar = src;
     //Define Rules
@@ -80,13 +84,16 @@ std::wstring CharacterStandard( const std::wstring& src ) {
     destChar = std::regex_replace( destChar, illegalCharRegex, L"_" );
     return destChar;
 }
+#endif
 
 HRESULT FileExtractCallback::getOutStream( uint32_t index, ISequentialOutStream** outStream ) {
     mCurrentItem.loadItemInfo( inputArchive(), index );
 
     auto filePath = getCurrentItemPath();
+#ifdef _WIN32
     // Normalize String
     filePath = CharacterStandard( filePath.wstring() );
+#endif
     mFilePathOnDisk = mDirectoryPath / filePath;
 
 #if defined( _WIN32 ) && defined( BIT7Z_AUTO_PREFIX_LONG_PATHS )

--- a/src/internal/fsutil.cpp
+++ b/src/internal/fsutil.cpp
@@ -309,8 +309,8 @@ inline auto sanitize_path_component( std::wstring component ) -> std::wstring {
     // Replacing all reserved characters in the component with the '_' character.
     std::replace_if( component.begin(), component.end(), []( wchar_t chr ) {
         constexpr auto last_non_printable_ascii = 31;
-        return chr <= last_non_printable_ascii || chr == L'[' || chr == L'<' || chr == L'>' || chr == L':' ||
-               chr == L'"' || chr == L'/' || chr == L'|' || chr == L'?' || chr == L'*' || chr == L']';
+        return chr <= last_non_printable_ascii || chr == L'<' || chr == L'>' || chr == L':' ||
+               chr == L'"' || chr == L'/' || chr == L'|' || chr == L'?' || chr == L'*';
     }, L'_' );
     return component;
 }

--- a/src/internal/fsutil.cpp
+++ b/src/internal/fsutil.cpp
@@ -303,7 +303,8 @@ inline auto is_windows_reserved_name( const std::wstring& component ) -> bool {
 inline auto sanitize_path_component( std::wstring component ) -> std::wstring {
     // If the component is a reserved name on Windows, we prepend it with a '_' character.
     if ( is_windows_reserved_name( component ) ) {
-        component.insert( 0, 1, '_' );
+        component.insert( 0, 1, L'_' );
+        return component;
     }
 
     // Replacing all reserved characters in the component with the '_' character.

--- a/src/internal/fsutil.cpp
+++ b/src/internal/fsutil.cpp
@@ -21,6 +21,10 @@
 #include "internal/dateutil.hpp"
 #endif
 
+#if defined( _WIN32 ) && defined( BIT7Z_PATH_SANITIZATION )
+#include <cwctype> // for iswdigit
+#endif
+
 using namespace std;
 using namespace bit7z;
 using namespace bit7z::filesystem;
@@ -280,4 +284,43 @@ auto fsutil::format_long_path( const fs::path& path ) -> fs::path {
     return long_path;
 }
 
+#endif
+
+#if defined( _WIN32 ) && defined( BIT7Z_PATH_SANITIZATION )
+inline auto is_windows_reserved_name( const std::wstring& component ) -> bool {
+    // Reserved file names that can't be used on Windows: CON, PRN, AUX, and NUL.
+    if ( component == L"CON" || component == L"PRN" || component == L"AUX" || component == L"NUL" ) {
+        return true;
+    }
+    // Reserved file names that can't be used on Windows:
+    // COM0, COM1, COM2, COM3, COM4, COM5, COM6, COM7, COM8, COM9,
+    // LPT0, LPT1, LPT2, LPT3, LPT4, LPT5, LPT6, LPT7, LPT8, and LPT9.
+    return component.size() == 4 &&
+           ( component.find(L"COM") == 0 || component.find(L"LPT") == 0 ) &&
+           std::iswdigit( component.back() ) != 0;
+}
+
+inline auto sanitize_path_component( std::wstring component ) -> std::wstring {
+    // If the component is a reserved name on Windows, we prepend it with a '_' character.
+    if ( is_windows_reserved_name( component ) ) {
+        component.insert( 0, 1, '_' );
+    }
+
+    // Replacing all reserved characters in the component with the '_' character.
+    std::replace_if( component.begin(), component.end(), []( wchar_t chr ) {
+        constexpr auto last_non_printable_ascii = 31;
+        return chr <= last_non_printable_ascii || chr == L'[' || chr == L'<' || chr == L'>' || chr == L':' ||
+               chr == L'"' || chr == L'/' || chr == L'|' || chr == L'?' || chr == L'*' || chr == L']';
+    }, L'_' );
+    return component;
+}
+
+auto sanitize_path( const fs::path& path ) -> fs::path {
+    fs::path sanitized_path = path.root_path().make_preferred();
+    for( const auto& path_component : path.relative_path() ) {
+        // cppcheck-suppress useStlAlgorithm
+        sanitized_path /= sanitize_path_component( path_component.wstring() );
+    }
+    return sanitized_path;
+}
 #endif

--- a/src/internal/fsutil.cpp
+++ b/src/internal/fsutil.cpp
@@ -315,7 +315,7 @@ inline auto sanitize_path_component( std::wstring component ) -> std::wstring {
     return component;
 }
 
-auto sanitize_path( const fs::path& path ) -> fs::path {
+auto fsutil::sanitize_path( const fs::path& path ) -> fs::path {
     fs::path sanitized_path = path.root_path().make_preferred();
     for( const auto& path_component : path.relative_path() ) {
         // cppcheck-suppress useStlAlgorithm

--- a/src/internal/fsutil.hpp
+++ b/src/internal/fsutil.hpp
@@ -50,6 +50,18 @@ BIT7Z_NODISCARD auto format_long_path( const fs::path& path ) -> fs::path;
 #   define FORMAT_LONG_PATH( path ) path
 #endif
 
+#if defined( _WIN32 ) && defined( BIT7Z_PATH_SANITIZATION )
+/**
+ * Sanitizes the given file path, removing any eventual Windows illegal character
+ * (https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file)
+ *
+ * @param path The path to be sanitized.
+ *
+ * @return the sanitized path, where illegal characters are replaced with the '_' character.
+ */
+auto sanitize_path( const fs::path& path ) -> fs::path;
+#endif
+
 }  // namespace fsutil
 }  // namespace filesystem
 }  // namespace bit7z

--- a/tests/src/test_fsutil.cpp
+++ b/tests/src/test_fsutil.cpp
@@ -174,3 +174,54 @@ TEST_CASE( "fsutil: Wildcard matching with both question mark and star", "[fsuti
     REQUIRE( wildcardMatch( BIT7Z_STRING( "?**?d?" ), BIT7Z_STRING( "abcd" ) ) == false );
     REQUIRE( wildcardMatch( BIT7Z_STRING( "?*b*?*d*?" ), BIT7Z_STRING( "abcde" ) ) == true );
 }
+
+#if defined( _WIN32 ) && defined( BIT7Z_PATH_SANITIZATION )
+TEST_CASE( "fsutil: Sanitizing Windows paths", "[fsutil][sanitize_path]" ) {
+    REQUIRE( sanitize_path( L"hello world.txt" ) == L"hello world.txt" );
+    REQUIRE( sanitize_path( L"hello?world<" ) == L"hello_world_" );
+    REQUIRE( sanitize_path( L":hello world|" ) == L"_hello world_" );
+    REQUIRE( sanitize_path( L"hello?world<.txt" ) == L"hello_world_.txt" );
+    REQUIRE( sanitize_path( L":hello world|.txt" ) == L"_hello world_.txt" );
+
+    REQUIRE( sanitize_path( L"COM0" ) == L"_COM0" );
+    REQUIRE( sanitize_path( L"COM0.txt" ) == L"COM0.txt" );
+    REQUIRE( sanitize_path( L"LPT9" ) == L"_LPT9" );
+    REQUIRE( sanitize_path( L"LPT9.txt" ) == L"LPT9.txt" );
+    REQUIRE( sanitize_path( L"COM42" ) == L"COM42" );
+    REQUIRE( sanitize_path( L"LPT42" ) == L"LPT42" );
+
+    REQUIRE( sanitize_path( L"CON" ) == L"_CON" );
+    REQUIRE( sanitize_path( L"PRN" ) == L"_PRN" );
+    REQUIRE( sanitize_path( L"AUX" ) == L"_AUX" );
+    REQUIRE( sanitize_path( L"NUL" ) == L"_NUL" );
+    REQUIRE( sanitize_path( L"CONO" ) == L"CONO" );
+    REQUIRE( sanitize_path( L"PRNG" ) == L"PRNG" );
+    REQUIRE( sanitize_path( L"AUXI" ) == L"AUXI" );
+    REQUIRE( sanitize_path( L"NULL" ) == L"NULL" );
+
+    REQUIRE( sanitize_path( L"C:/abc/NUL/def" ) == L"C:\\abc\\_NUL\\def" );
+    REQUIRE( sanitize_path( L"C:\\abc\\NUL\\def" ) == L"C:\\abc\\_NUL\\def" );
+
+    REQUIRE( sanitize_path( L"C:/Test/COM0/hello?world<.txt" ) == L"C:\\Test\\_COM0\\hello_world_.txt" );
+    REQUIRE( sanitize_path( L"C:\\Test\\COM0\\hello?world<.txt" ) == L"C:\\Test\\_COM0\\hello_world_.txt" );
+    REQUIRE( sanitize_path( L"Test/COM0/hello?world<.txt" ) == L"Test\\_COM0\\hello_world_.txt" );
+    REQUIRE( sanitize_path( L"Test\\COM0\\hello?world<.txt" ) == L"Test\\_COM0\\hello_world_.txt" );
+    REQUIRE( sanitize_path( L"../COM0/hello?world<.txt" ) == L"..\\_COM0\\hello_world_.txt" );
+    REQUIRE( sanitize_path( L"..\\COM0\\hello?world<.txt" ) == L"..\\_COM0\\hello_world_.txt" );
+    REQUIRE( sanitize_path( L"./COM0/hello?world<.txt" ) == L".\\_COM0\\hello_world_.txt" );
+    REQUIRE( sanitize_path( L".\\COM0\\hello?world<.txt" ) == L".\\_COM0\\hello_world_.txt" );
+    REQUIRE( sanitize_path( L"COM0/hello?world<.txt" ) == L"_COM0\\hello_world_.txt" );
+    REQUIRE( sanitize_path( L"COM0\\hello?world<.txt" ) == L"_COM0\\hello_world_.txt" );
+
+    REQUIRE( sanitize_path( L"C:/Test/:hello world|/LPT5" ) == L"C:\\Test\\_hello world_\\_LPT5" );
+    REQUIRE( sanitize_path( L"C:\\Test\\:hello world|\\LPT5" ) == L"C:\\Test\\_hello world_\\_LPT5" );
+    REQUIRE( sanitize_path( L"Test/:hello world|/LPT5" ) == L"Test\\_hello world_\\_LPT5" );
+    REQUIRE( sanitize_path( L"Test\\:hello world|\\LPT5" ) == L"Test\\_hello world_\\_LPT5" );
+    REQUIRE( sanitize_path( L"../:hello world|/LPT5" ) == L"..\\_hello world_\\_LPT5" );
+    REQUIRE( sanitize_path( L"..\\:hello world|\\LPT5" ) == L"..\\_hello world_\\_LPT5" );
+    REQUIRE( sanitize_path( L"./:hello world|/LPT5" ) == L".\\_hello world_\\_LPT5" );
+    REQUIRE( sanitize_path( L".\\:hello world|\\LPT5" ) == L".\\_hello world_\\_LPT5" );
+    REQUIRE( sanitize_path( L":hello world|/LPT5" ) == L"_hello world_\\_LPT5" );
+    REQUIRE( sanitize_path( L":hello world|\\LPT5" ) == L"_hello world_\\_LPT5" );
+}
+#endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix a bug where the compressed package contains special characters under the window as directory or file names, resulting in file creation failure.
The location where the bug appears:
Fs:: create for bit7z src internal fileextraccallback.cpp file_ The directories function.
Repair plan:
Using regular expressions to replace special characters with the "_" character supported by window can solve the problem.
std::wstring CharacterStandard(const std::wstring& src)
{
	std::wstring destChar = src;
	//Define Rules
	std::wregex illegalCharRegex(L"[<>:\"/|?*]");
	//Replacing illegal characters with underscores using regular expressions
    destChar = std::regex_replace(destChar, illegalCharRegex, L"_");
	return destChar.c_str();
}
Remaining issues:
1. Currently, only the wide character version is available
2. The special file name was not processed, only special characters were processed. Special file names include:
The file name cannot start or end with a space, nor can it contain one of the following device names: CON, PRN, AUX, NUL, COM1, COM2, COM3, COM4, COM5, COM6, COM7, COM8, COM9, LPT1, LPT2, LPT3, LPT4, LPT5, LPT6, LPT7, LPT8, LPT9

## Motivation and Context
Some users' compressed packages contain special characters as the file name for the compressed content, which causes an exception to be thrown when creating the file and prevents normal decompression.

## How Has This Been Tested?
You can generate compressed packages containing the following window special characters as directory or file names on the Mac platform for decompression.
<(less than sign)
>(greater than sign)
: (colon)
"(Double quotes)
/(forward slash)
\(backslash)
|(Vertical line)
? (Question mark)
*(asterisk)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
<!-- TODO: - [ ] I have read the **CONTRIBUTING** document. -->