### PR TITLE
fix: add missing <algorithm> header (gcc14)

### DIFF
--- a/src/bitinputarchive.cpp
+++ b/src/bitinputarchive.cpp
@@ -33,6 +33,8 @@
 #include "internal/formatdetect.hpp"
 #endif
 
+#include <algorithm>
+
 using namespace NWindows;
 using namespace NArchive;
 


### PR DESCRIPTION
gcc14 is complaining about unknown "std::find_if" function. (gcc13 works fine)

<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds the header <algorithm> to `bitinputarchive.cpp`.

## Motivation and Context
project isn't compiling with gcc14. It complains about `std::find_if` not known function.

## How Has This Been Tested?
I simply compiled it with gcc14.1.1, no further tests.

## Types of changes
Nothing changed.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project. (style is unclear to me)
- [ ] My change requires a change to the documentation. (not required)
- [ ] I have updated the documentation accordingly. (not required)