### PR TITLE
[Fix] Unbuffered streams causing poor performance with MSVC 2015

### DIFF
--- a/src/internal/cfileinstream.cpp
+++ b/src/internal/cfileinstream.cpp
@@ -20,9 +20,14 @@ CFileInStream::CFileInStream( const fs::path& filePath ) : CStdInStream( mFileSt
     /* Disabling std::ifstream's buffering, as unbuffered IO gives better performance
      * with the block sizes read/written by 7-Zip.
      * Note: we need to do this before and after opening the file (https://stackoverflow.com/a/59161297/3497024). */
+
     mFileStream.rdbuf()->pubsetbuf( nullptr, 0 );
     openFile( filePath );
+
+// Unbuffered streams are weirdly slow for Visual Studio 2015
+#if defined(_MSVC_VER) && _MSVC_VER != 1900
     mFileStream.rdbuf()->pubsetbuf( nullptr, 0 );
+#endif
 }
 
 void CFileInStream::openFile( const fs::path& filePath ) {

--- a/src/internal/cfileinstream.cpp
+++ b/src/internal/cfileinstream.cpp
@@ -22,9 +22,8 @@ CFileInStream::CFileInStream( const fs::path& filePath ) : CStdInStream( mFileSt
      * Note: we need to do this before and after opening the file (https://stackoverflow.com/a/59161297/3497024). */
     mFileStream.rdbuf()->pubsetbuf( nullptr, 0 );
     openFile( filePath );
-
 // Unbuffered streams are slow for Visual Studio 2015
-#if defined(_MSVC_VER) && _MSVC_VER != 1900
+#if defined(_MSC_VER) && _MSC_VER != 1900
     mFileStream.rdbuf()->pubsetbuf( nullptr, 0 );
 #endif
 }

--- a/src/internal/cfileinstream.cpp
+++ b/src/internal/cfileinstream.cpp
@@ -20,11 +20,10 @@ CFileInStream::CFileInStream( const fs::path& filePath ) : CStdInStream( mFileSt
     /* Disabling std::ifstream's buffering, as unbuffered IO gives better performance
      * with the block sizes read/written by 7-Zip.
      * Note: we need to do this before and after opening the file (https://stackoverflow.com/a/59161297/3497024). */
-
     mFileStream.rdbuf()->pubsetbuf( nullptr, 0 );
     openFile( filePath );
 
-// Unbuffered streams are weirdly slow for Visual Studio 2015
+// Unbuffered streams are slow for Visual Studio 2015
 #if defined(_MSVC_VER) && _MSVC_VER != 1900
     mFileStream.rdbuf()->pubsetbuf( nullptr, 0 );
 #endif

--- a/src/internal/cfileinstream.cpp
+++ b/src/internal/cfileinstream.cpp
@@ -23,7 +23,7 @@ CFileInStream::CFileInStream( const fs::path& filePath ) : CStdInStream( mFileSt
     mFileStream.rdbuf()->pubsetbuf( nullptr, 0 );
     openFile( filePath );
 // Unbuffered streams are slow for Visual Studio 2015
-#if defined(_MSC_VER) && _MSC_VER != 1900
+#if !defined(_MSC_VER) || _MSC_VER != 1900
     mFileStream.rdbuf()->pubsetbuf( nullptr, 0 );
 #endif
 }

--- a/src/internal/cfileoutstream.cpp
+++ b/src/internal/cfileoutstream.cpp
@@ -32,6 +32,7 @@ CFileOutStream::CFileOutStream( fs::path filePath, bool createAlways )
     /* Disabling std::ofstream's buffering, as unbuffered IO gives better performance
      * with the block sizes read/written by 7-Zip.
      * Note: we need to do this before and after opening the file (https://stackoverflow.com/a/59161297/3497024). */
+
     mFileStream.rdbuf()->pubsetbuf( nullptr, 0 );
     mFileStream.open( mFilePath, std::ios::binary | std::ios::trunc ); // flawfinder: ignore
     if ( mFileStream.fail() ) {
@@ -42,7 +43,11 @@ CFileOutStream::CFileOutStream( fs::path filePath, bool createAlways )
         throw BitException( "Failed to open the output file", last_error_code(), path_to_tstring( mFilePath ) );
 #endif
     }
+
+// Unbuffered streams are weirdly slow for Visual Studio 2015
+#if defined(_MSVC_VER) && _MSVC_VER != 1900
     mFileStream.rdbuf()->pubsetbuf( nullptr, 0 );
+#endif
 }
 
 auto CFileOutStream::fail() const -> bool {

--- a/src/internal/cfileoutstream.cpp
+++ b/src/internal/cfileoutstream.cpp
@@ -42,9 +42,8 @@ CFileOutStream::CFileOutStream( fs::path filePath, bool createAlways )
         throw BitException( "Failed to open the output file", last_error_code(), path_to_tstring( mFilePath ) );
 #endif
     }
-
 // Unbuffered streams are slow for Visual Studio 2015
-#if defined(_MSVC_VER) && _MSVC_VER != 1900
+#if defined(_MSC_VER) && _MSC_VER != 1900
     mFileStream.rdbuf()->pubsetbuf( nullptr, 0 );
 #endif
 }

--- a/src/internal/cfileoutstream.cpp
+++ b/src/internal/cfileoutstream.cpp
@@ -32,7 +32,6 @@ CFileOutStream::CFileOutStream( fs::path filePath, bool createAlways )
     /* Disabling std::ofstream's buffering, as unbuffered IO gives better performance
      * with the block sizes read/written by 7-Zip.
      * Note: we need to do this before and after opening the file (https://stackoverflow.com/a/59161297/3497024). */
-
     mFileStream.rdbuf()->pubsetbuf( nullptr, 0 );
     mFileStream.open( mFilePath, std::ios::binary | std::ios::trunc ); // flawfinder: ignore
     if ( mFileStream.fail() ) {
@@ -44,7 +43,7 @@ CFileOutStream::CFileOutStream( fs::path filePath, bool createAlways )
 #endif
     }
 
-// Unbuffered streams are weirdly slow for Visual Studio 2015
+// Unbuffered streams are slow for Visual Studio 2015
 #if defined(_MSVC_VER) && _MSVC_VER != 1900
     mFileStream.rdbuf()->pubsetbuf( nullptr, 0 );
 #endif

--- a/src/internal/cfileoutstream.cpp
+++ b/src/internal/cfileoutstream.cpp
@@ -43,7 +43,7 @@ CFileOutStream::CFileOutStream( fs::path filePath, bool createAlways )
 #endif
     }
 // Unbuffered streams are slow for Visual Studio 2015
-#if defined(_MSC_VER) && _MSC_VER != 1900
+#if !defined(_MSC_VER) || _MSC_VER != 1900
     mFileStream.rdbuf()->pubsetbuf( nullptr, 0 );
 #endif
 }


### PR DESCRIPTION
When compiled using Visual Studio 2015 bit7z will use the default buffer size instead of being unbuffered.

## Description

Uses `#if defined(_MSC_VER) && _MSC_VER != 1900` so that CFileOutStream & CFileInStream will use the default buffer size rather than unbuffered file streams for MSVC 2015.

## Motivation and Context

CFileOutStream & CFileInStream were recently modified to call pubsetbuf() with a zero buffer size to improve performance; however, MSVC 2015 appears to have an issue with this. Extracting a [7MB archive](https://github.com/user-attachments/files/17235704/test.zip) on a fast machine took 18 seconds. Following my change the same archive took 0.2 seconds.

I did the same test in Visual Studio 2022 and performance was ~0.2 seconds, so I have not tested reverting the change and have restricted my change to MSVC 2015. I do not know how many MSVC versions between 2015 and 2022 have this problem.

## How Has This Been Tested?

I was unable to build the project tests, but I was able to reproduce the issue in a console application with the following code:

```
void extract(std::string filepath, std::string outpath)
{
	auto start = std::chrono::steady_clock::now();
	bit7z::Bit7zLibrary lib{ "7z.dll" };
	bit7z::BitArchiveReader archive{ lib, filepath, bit7z::BitFormat::Zip };
	archive.extractTo(outpath);
	std::cout << std::chrono::duration_cast<std::chrono::duration<double>>(std::chrono::steady_clock::now() - start).count();
}
```

I used static runtime, Visual Studio 2015 update 3 or Visual Studio 2022 (17.11.4), running on a Windows 11 Pro machine with a 7z.dll from a 7-zip installation.

The underlying issue with streams in 2015 can be observed with std::ifstream in a console application and calling pubsetbuf() with a zero buffer size, and reading files of various sizes.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.