### PR TITLE
Fix arm alignment compiler errors

### DIFF
--- a/src/internal/windows.cpp
+++ b/src/internal/windows.cpp
@@ -68,19 +68,18 @@ auto AllocStringBuffer( LPCSTR str, uint32_t byteLength ) -> BSTR {
 
     // Allocating memory for storing the BSTR as a byte array.
     // NOLINTNEXTLINE(cppcoreguidelines-no-malloc, cppcoreguidelines-owning-memory)
-    auto* bstrBuffer = static_cast< byte_t* >( std::calloc( bufferSize, sizeof( byte_t ) ) );
+    auto* bstrBuffer = static_cast< bstr_prefix_t* >( std::calloc( bufferSize, sizeof( byte_t ) ) );
 
     if ( bstrBuffer == nullptr ) { // Failed to allocate memory for the BSTR buffer.
         return nullptr;
     }
 
     // Storing the number of bytes of the BSTR as a prefix of it.
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
-    *reinterpret_cast< bstr_prefix_t* >( bstrBuffer ) = byteLength;
+    *bstrBuffer = byteLength;
 
     // The actual BSTR must point after the byteLength prefix.
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic, cppcoreguidelines-pro-type-reinterpret-cast)
-    BSTR result = reinterpret_cast< BSTR >( bstrBuffer + sizeof( bstr_prefix_t ) );
+    BSTR result = reinterpret_cast< BSTR >( bstrBuffer + 1 );
     if ( str != nullptr ) {
         // Copying byte-by-byte the input string to the BSTR.
         // Note: flawfinder warns about not checking for buffer overflows; this is a false alarm,


### PR DESCRIPTION
Building on 32-bit arm, following warning/error occurs:

```
src/internal/windows.cpp: In function 'bit7z::OLECHAR* AllocStringBuffer(LPCSTR, uint32_t)': src/internal/windows.cpp:79:6: error: cast from 'unsigned char*' to 'bstr_prefix_t*' {aka 'unsigned int*'} increases required alignment of target type [-Werror=cast-align]
   79 |     *reinterpret_cast< bstr_prefix_t* >( bstrBuffer ) = byteLength;
      |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
git/src/internal/windows.cpp:83:19: error: cast from 'unsigned char*' to 'bit7z::BSTR' {aka 'wchar_t*'} increases required alignment of target type [-Werror=cast-align]
   83 |     BSTR result = reinterpret_cast< BSTR >( bstrBuffer + sizeof( bstr_prefix_t ) );
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```

## Description

Fix the problem by using the desired variable size right away and thus avoid casting to an array with different alignment.

## Motivation and Context

This is required to successfully build the project on 32-bit arm (or other architectures with strict alignment requirements) with reasonable warning levels.

## How Has This Been Tested?

This was tested running fulltest suites bit7z-tests-public and bit7z-tests for x86, x86-64, arm and arm64.
Tests were executed under Yocto project environment in qemu.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] ~~New feature (non-breaking change which adds functionality)~~
- [ ] ~~Breaking change (fix or feature that would cause existing functionality to change)~~

## Checklist:

- [x] My code follows the code style of this project.
- [ ] ~~My change requires a change to the documentation.~~
- [ ] ~~I have updated the documentation accordingly.~~
