### PR TITLE
Fix bitpropvariant int8_t for arm (both 32 and 64 bit)

### DIFF
--- a/include/bit7z/bitwindows.hpp
+++ b/include/bit7z/bitwindows.hpp
@@ -126,7 +126,7 @@ struct PROPVARIANT {
     WORD wReserved2;
     WORD wReserved3;
     union {
-        char cVal;
+        signed char cVal;
         unsigned char bVal;
         short iVal;
         unsigned short uiVal;

--- a/src/bitpropvariant.cpp
+++ b/src/bitpropvariant.cpp
@@ -157,7 +157,7 @@ BitPropVariant::BitPropVariant( uint64_t value ) noexcept: PROPVARIANT() {
 BitPropVariant::BitPropVariant( int8_t value ) noexcept: PROPVARIANT() {
     vt = VT_I1;
     wReserved1 = 0;
-    cVal = static_cast< char >( value );
+    cVal = value;
 }
 
 BitPropVariant::BitPropVariant( int16_t value ) noexcept: PROPVARIANT() {


### PR DESCRIPTION
char is unsigned on this architecture.

Test are failing with e.g.:

```
-------------------------------------------------------------------------------
BitPropVariant: Integer variant - int8_t
-------------------------------------------------------------------------------
/usr/src/debug/bit7z/4.0.9/tests/src/test_bitpropvariant.cpp:520
...............................................................................

/usr/src/debug/bit7z/4.0.9/tests/src/test_bitpropvariant.cpp:549: FAILED:
  REQUIRE( propVariant.toString() == int_to_tstring( value ) )
with expansion:
  "128" == "-127"
```

## Description

Explicitly mark cVal as signed char.

I believe that commit b46fef7ac06c28d28e4c646bc837cb92e8792fa9 was incorrect as it made the build green, but the execution broken.

## Motivation and Context

This is required to successfully run testsuites 32 and 64 bit bit arm (or other architectures with char being unsigned)

## How Has This Been Tested?

This was tested running fulltest suites bit7z-tests-public and bit7z-tests for x86, x86-64, arm and arm64.
Tests were executed under Yocto project environment in qemu.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] ~~New feature (non-breaking change which adds functionality)~~
- [ ] ~~Breaking change (fix or feature that would cause existing functionality to change)~~

## Checklist:

- [x] My code follows the code style of this project.
- [ ] ~~My change requires a change to the documentation.~~
- [ ] ~~I have updated the documentation accordingly.~~
