### PR TITLE
Allow running tests on target when cross-compiling

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,6 +49,11 @@ add_executable( ${TESTS_TARGET_PUBLIC} ${SOURCE_FILES} ${PUBLIC_API_SOURCE_FILES
 
 if( BIT7Z_TESTS_FILESYSTEM )
     set( BIT7Z_TESTS_DATA_DIR ${CMAKE_CURRENT_BINARY_DIR}/data )
+    if( NOT BIT7Z_TESTS_DATA_DIR_TARGET )
+        set( BIT7Z_TESTS_DATA_DIR_TARGET ${BIT7Z_TESTS_DATA_DIR} )
+    else()
+        message( STATUS "Custom test data dir on target: ${BIT7Z_TESTS_DATA_DIR_TARGET}" )
+    endif()
 
     include( FetchContent )
     FetchContent_Declare( bit7z-test-data
@@ -61,11 +66,11 @@ if( BIT7Z_TESTS_FILESYSTEM )
     message( STATUS "Tests data directory: ${BIT7Z_TESTS_DATA_DIR}" )
     target_compile_definitions( ${TESTS_TARGET} PRIVATE
                                 BIT7Z_TESTS_FILESYSTEM
-                                BIT7Z_TESTS_DATA_DIR="${BIT7Z_TESTS_DATA_DIR}" )
+                                BIT7Z_TESTS_DATA_DIR="${BIT7Z_TESTS_DATA_DIR_TARGET}" )
     target_compile_definitions( ${TESTS_TARGET_PUBLIC} PRIVATE
                                 BIT7Z_TESTS_PUBLIC_API_ONLY
                                 BIT7Z_TESTS_FILESYSTEM
-                                BIT7Z_TESTS_DATA_DIR="${BIT7Z_TESTS_DATA_DIR}" )
+                                BIT7Z_TESTS_DATA_DIR="${BIT7Z_TESTS_DATA_DIR_TARGET}" )
     if( NOT EXISTS ${BIT7Z_TESTS_DATA_DIR}/test_filesystem/empty )
         file( MAKE_DIRECTORY ${BIT7Z_TESTS_DATA_DIR}/test_filesystem/empty )
     endif()


### PR DESCRIPTION
When bit7z is cross-compiled, target device does not contain source/build directory anymore and thus path to test data is invalid. Make it possible to pass the new path to cmake.

## Description

Add new option to test cmake files to specify path of test data on target device.

## Motivation and Context

This is required to be able to run testsuites in cross-compile environments.

## How Has This Been Tested?

This was tested running fulltest suites bit7z-tests-public and bit7z-tests for x86, x86-64, arm and arm64.
Tests were executed under Yocto project environment in qemu.

## Types of changes

- [ ] ~~Bug fix (non-breaking change which fixes an issue)~~
- [ ] ~~New feature (non-breaking change which adds functionality)~~
- [ ] ~~Breaking change (fix or feature that would cause existing functionality to change)~~

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
