### PR TITLE
Fix tests with musl

### DIFF
--- a/tests/src/test_bitexception.cpp
+++ b/tests/src/test_bitexception.cpp
@@ -49,6 +49,8 @@ constexpr PortableErrorTest hresult_tests[] = { // NOLINT(*-avoid-c-arrays)
     { HRESULT_WIN32_TEST( ERROR_OPEN_FAILED ),
 #ifdef _WIN32
       "The system cannot open the device or file specified.",
+#elif defined( __linux__ ) && !defined ( __GLIBC__ )
+      "I/O error",
 #else
         "Input/output error",
 #endif
@@ -67,6 +69,8 @@ constexpr PortableErrorTest hresult_tests[] = { // NOLINT(*-avoid-c-arrays)
     { HRESULT_WIN32_TEST( ERROR_SEEK ),
 #ifdef _WIN32
       "The drive cannot locate a specific area or track on the disk.",
+#elif defined( __linux__ ) && !defined ( __GLIBC__ )
+      "I/O error",
 #else
         "Input/output error",
 #endif
@@ -74,6 +78,8 @@ constexpr PortableErrorTest hresult_tests[] = { // NOLINT(*-avoid-c-arrays)
     { HRESULT_WIN32_TEST( ERROR_READ_FAULT ),
 #ifdef _WIN32
       "The system cannot read from the specified device.",
+#elif defined( __linux__ ) && !defined ( __GLIBC__ )
+      "I/O error",
 #else
         "Input/output error",
 #endif
@@ -81,6 +87,8 @@ constexpr PortableErrorTest hresult_tests[] = { // NOLINT(*-avoid-c-arrays)
     { HRESULT_WIN32_TEST( ERROR_WRITE_FAULT ),
 #ifdef _WIN32
       "The system cannot write to the specified device.",
+#elif defined( __linux__ ) && !defined ( __GLIBC__ )
+      "I/O error",
 #else
         "Input/output error",
 #endif


### PR DESCRIPTION
## Description

When using musl instead od of glibc as c library, these tests are failing with
```
"I/O error" == "Input/output error"
```

There is already ifdef statement for different architectures so we can extend it.
Unfortunately musl developers don't provide __MUSL__ define (see e.g. [this article](https://catfox.life/2022/04/16/the-musl-preprocessor-debate/)).

I'm aware that this is suboptimal and works only if for Linux only glibc and musl are supported.
If not, then I we could maybe introduce a configuration option for this (e.g. `BIT7Z_BUILD_TESTS_WITH_MUSL`)?

## Motivation and Context

Yocto project is highly configurable tool and supports also musl in addition to glibc.
Let's try to support tests also with this c library.

## How Has This Been Tested?

Running full test suite with glibc on arm, arm64, x86 and x86-64 and with musl on arm and x86.
(arm64 and x86-64 are not available for musl as 7zip library does not build currently in Yocto for these)

## Types of changes

- [ ] ~~Bug fix (non-breaking change which fixes an issue)~~
- [ ] ~~New feature (non-breaking change which adds functionality)~~
- [ ] ~~Breaking change (fix or feature that would cause existing functionality to change)~~

## Checklist:

- [x] My code follows the code style of this project.
- [ ] ~~My change requires a change to the documentation.~~
- [ ] ~~I have updated the documentation accordingly.~~
