### PR TITLE
Add possibility to perform extraction to preallocated map of buffers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,8 @@ set( PUBLIC_HEADERS
      include/bit7z/bitstreamcompressor.hpp
      include/bit7z/bitstreamextractor.hpp
      include/bit7z/bittypes.hpp
-     include/bit7z/bitwindows.hpp )
+     include/bit7z/bitwindows.hpp
+     include/bit7z/bytespan.hpp)
 
 # header files
 set( HEADERS
@@ -76,6 +77,7 @@ set( HEADERS
      src/internal/failuresourcecategory.hpp
      src/internal/fileextractcallback.hpp
      src/internal/fixedbufferextractcallback.hpp
+     src/internal/fixedbuffersextractcallback.hpp
      src/internal/formatdetect.hpp
      src/internal/fsindexer.hpp
      src/internal/fsitem.hpp
@@ -98,7 +100,7 @@ set( HEADERS
      src/internal/stringutil.hpp
      src/internal/updatecallback.hpp
      src/internal/util.hpp
-     src/internal/windows.hpp )
+     src/internal/windows.hpp)
 
 # source files
 set( SOURCES
@@ -142,6 +144,7 @@ set( SOURCES
      src/internal/failuresourcecategory.cpp
      src/internal/fileextractcallback.cpp
      src/internal/fixedbufferextractcallback.cpp
+     src/internal/fixedbuffersextractcallback.cpp
      src/internal/formatdetect.cpp
      src/internal/fsindexer.cpp
      src/internal/fsitem.cpp

--- a/include/bit7z/bitextractor.hpp
+++ b/include/bit7z/bitextractor.hpp
@@ -99,6 +99,19 @@ class BitExtractor final : public BitAbstractArchiveOpener {
         }
 
         /**
+         * @brief Extracts the content of the given archive into a provided map of memory buffers, where the keys are
+         * indices of the files (inside the archive) to be extracted, and the values are preallocated buffers to
+         * which extraction is to be performed.
+         *
+         * @param inArchive             the input archive to be extracted.
+         * @param indicesWithBuffers    the map with indices of files and preallocated buffers.
+         */
+        void extract( Input inArchive, const std::map< uint32_t, ByteSpan > & indicesWithBuffers ) const {
+            BitInputArchive inputArchive( *this, inArchive );
+            inputArchive.extractTo( indicesWithBuffers );
+        }
+
+        /**
          * @brief Extracts the files in the archive that match the given wildcard pattern to the chosen directory.
          *
          * @param inArchive    the input archive to extract from.

--- a/include/bit7z/bitinputarchive.hpp
+++ b/include/bit7z/bitinputarchive.hpp
@@ -16,6 +16,7 @@
 #include "bitarchiveitemoffset.hpp"
 #include "bitformat.hpp"
 #include "bitfs.hpp"
+#include "bytespan.hpp"
 
 struct IInStream;
 struct IInArchive;
@@ -262,6 +263,16 @@ class BitInputArchive {
          */
         void extractTo( byte_t* buffer, std::size_t size, uint32_t index = 0 ) const;
 
+        /**
+         * @brief Extracts a file to the pre-allocated output buffer.
+         *
+         * @param memview the pre-allocated output buffer (which size must be equal to the unpacked size of the item).
+         * @param index  the index of the file to be extracted.
+         */
+        void extractTo( ByteSpan memview, uint32_t index = 0 ) const {
+            extractTo( memview.data(), memview.size(), index);
+        }
+
         BIT7Z_DEPRECATED_MSG("Since v4.0; please, use the extractTo method.")
         inline void extract( std::ostream& outStream, uint32_t index = 0 ) const {
             extractTo( outStream, index );
@@ -287,6 +298,15 @@ class BitInputArchive {
          * @param outMap   the output map.
          */
         void extractTo( std::map< tstring, std::vector< byte_t > >& outMap ) const;
+
+        /**
+         * @brief Extracts the content of the archive to a map of preallocated memory buffers as BitSpans (which size needs to match
+         * extracted item size of file at given idex), where the keys are the indices
+         * of the files, and the values are their decompressed contents.
+         *
+         * @param outputBuffers the map of indices of files to extract together with buffers indicating where to extract items.
+         */
+        void extractTo( const std::map< uint32_t, ByteSpan > & outputBuffers) const;
 
         /**
          * @brief Tests the archive without extracting its content.

--- a/include/bit7z/bytespan.hpp
+++ b/include/bit7z/bytespan.hpp
@@ -1,0 +1,48 @@
+/*
+* bit7z - A C++ static library to interface with the 7-zip shared libraries.
+ * Copyright (c) 2014-2023 Riccardo Ostani - All Rights Reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef BYTESPAN_HPP
+#define BYTESPAN_HPP
+
+#include <bittypes.hpp>
+#ifdef __cpp_lib_span
+#include <span>
+#ifdef __cpp_lib_byte
+#include <cstddef>
+#endif
+#endif
+
+namespace bit7z {
+
+class ByteSpan {
+public:
+    ByteSpan() = default;
+    ByteSpan(byte_t* ptr, std::size_t const size) : mMemoryPointer(ptr), mSize(size){}
+
+#ifdef __cpp_lib_span
+#ifdef __cpp_lib_byte
+    /*implicit*/ ByteSpan(std::span<std::byte> view) : BitSpan(reinterpret_cast<byte_t*>(view.data(), view.size())) {}
+#endif
+    /*implicit*/ ByteSpan(std::span<char> view) : BitSpan(reinterpret_cast<char*>(view.data(), view.size())) {}
+    /*implicit*/ ByteSpan(std::span<unsigned char> view) : : BitSpan(reinterpret_cast<unsigned char*>(view.data(), view.size())) {}
+#endif
+
+    byte_t* data() { return mMemoryPointer;}
+    byte_t const* data() const { return mMemoryPointer;}
+    std::size_t size() const { return mSize;}
+
+    bool empty() const { return data() == nullptr;}
+private:
+    byte_t* mMemoryPointer = nullptr;
+    std::size_t mSize = 0;
+};
+
+}
+
+#endif //BYTESPAN_HPP

--- a/src/bitinputarchive.cpp
+++ b/src/bitinputarchive.cpp
@@ -35,6 +35,8 @@
 
 #include <algorithm>
 
+#include "internal/fixedbuffersextractcallback.hpp"
+
 using namespace NWindows;
 using namespace NArchive;
 
@@ -267,6 +269,19 @@ inline auto findInvalidIndex( const std::vector< uint32_t >& indices,
     });
 }
 
+inline auto findInvalidIndex( const std::map< uint32_t, ByteSpan >& indices,
+                          uint32_t itemsCount ) -> std::map< uint32_t, ByteSpan >::const_iterator {
+    return std::find_if( indices.cbegin(), indices.cend(), [&]( auto const& element ) -> bool {
+        return element.first >= itemsCount;
+    });
+}
+
+inline auto findNullBuffer( const std::map< uint32_t, ByteSpan >& indices ) -> std::map< uint32_t, ByteSpan >::const_iterator {
+    return std::find_if( indices.cbegin(), indices.cend(), [&]( auto const& element ) -> bool {
+        return element.second.data() == nullptr;
+    });
+}
+
 void BitInputArchive::extractTo( const tstring& outDir, const std::vector< uint32_t >& indices ) const {
     // Find if any index passed by the user is not in the valid range [0, itemsCount() - 1]
     const auto invalidIndex = findInvalidIndex( indices, itemsCount() );
@@ -354,6 +369,40 @@ void BitInputArchive::extractTo( std::map< tstring, std::vector< byte_t > >& out
 
     auto extractCallback = bit7z::make_com< BufferExtractCallback, ExtractCallback >( *this, outMap );
     extract_arc( mInArchive, filesIndices, extractCallback );
+}
+
+void BitInputArchive::extractTo( const std::map<uint32_t, ByteSpan>& outputBuffers ) const {
+    const auto invalidIndex = findInvalidIndex(outputBuffers, itemsCount());
+    if (invalidIndex != outputBuffers.cend()) {
+        throw BitException( "Cannot extract the item at the index " + std::to_string( invalidIndex->first ) + " to the buffer",
+                            make_error_code( BitError::InvalidIndex ) );
+    }
+
+    const auto nullBufferItem = findNullBuffer(outputBuffers);
+    if (nullBufferItem != outputBuffers.cend()) {
+        throw BitException( "Cannot extract the item at the index " + std::to_string( nullBufferItem->first ) + " to the buffer",
+                            make_error_code( BitError::NullOutputBuffer ) );
+    }
+
+    const auto invalidSizeBuffer = std::find_if(outputBuffers.cbegin(), outputBuffers.cend(), [this](const auto& element) {
+        const uint32_t& index = element.first;
+        const ByteSpan& buffer = element.second;
+        auto itemSize = itemProperty(index, BitProperty::Size).getUInt64();
+        return itemSize != buffer.size();
+    });
+
+    if (invalidSizeBuffer != outputBuffers.cend()) {
+        throw BitException("Cannot extract the item at the index " + std::to_string( invalidSizeBuffer->first ) + " to the buffer", make_error_code( BitError::InvalidOutputBufferSize ));
+    }
+
+    std::vector< uint32_t > indices;
+    indices.reserve(outputBuffers.size());
+    for (const auto& [idx, buffer] : outputBuffers) {
+        indices.push_back(idx);
+    }
+
+    auto extractCallback = bit7z::make_com< FixedBuffersExtractCallback, ExtractCallback >( *this, outputBuffers );
+    extract_arc( mInArchive, indices, extractCallback);
 }
 
 void BitInputArchive::test() const {

--- a/src/internal/fixedbufferextractcallback.hpp
+++ b/src/internal/fixedbufferextractcallback.hpp
@@ -29,14 +29,14 @@ class FixedBufferExtractCallback final : public ExtractCallback {
 
         ~FixedBufferExtractCallback() override = default;
 
+        void releaseStream() override;
+
+        auto getOutStream( uint32_t index, ISequentialOutStream** outStream ) -> HRESULT override;
+
     private:
         byte_t* mBuffer;
         size_t mSize;
         CMyComPtr< ISequentialOutStream > mOutMemStream;
-
-        void releaseStream() override;
-
-        auto getOutStream( uint32_t index, ISequentialOutStream** outStream ) -> HRESULT override;
 };
 
 }  // namespace bit7z

--- a/src/internal/fixedbuffersextractcallback.cpp
+++ b/src/internal/fixedbuffersextractcallback.cpp
@@ -1,0 +1,43 @@
+/*
+* bit7z - A C++ static library to interface with the 7-zip shared libraries.
+ * Copyright (c) 2014-2022 Riccardo Ostani - All Rights Reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "fixedbuffersextractcallback.hpp"
+
+
+namespace bit7z {
+
+FixedBuffersExtractCallback::FixedBuffersExtractCallback(const BitInputArchive &inputArchive, std::map<uint32_t, ByteSpan> buffers) :
+    ExtractCallback(inputArchive),
+    mBuffers(std::move(buffers)) {
+     for (auto& [idx, buffer] : mBuffers) {
+         mBuffersCallbacks.emplace(std::piecewise_construct, std::make_tuple(idx), std::make_tuple(std::ref(inputArchive), buffer.data(), buffer.size()));
+     }
+}
+
+void FixedBuffersExtractCallback::releaseStream() {
+    for (auto& [idx, callback] : mBuffersCallbacks) {
+        callback.releaseStream();
+    }
+}
+
+auto FixedBuffersExtractCallback::getOutStream(uint32_t index, ISequentialOutStream **outStream) -> HRESULT {
+    if ( isItemFolder( index ) ) {
+        return S_OK;
+    }
+
+    auto const found_it = mBuffersCallbacks.find(index);
+    if (found_it == mBuffersCallbacks.end()) {
+        return E_FAIL;
+    }
+
+    auto& callback = found_it->second;
+    return callback.getOutStream(index, outStream);
+}
+
+}

--- a/src/internal/fixedbuffersextractcallback.hpp
+++ b/src/internal/fixedbuffersextractcallback.hpp
@@ -1,0 +1,46 @@
+/*
+* bit7z - A C++ static library to interface with the 7-zip shared libraries.
+ * Copyright (c) 2014-2022 Riccardo Ostani - All Rights Reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef FIXEDBUFFERSEXTRACTCALLBACK_HPP
+#define FIXEDBUFFERSEXTRACTCALLBACK_HPP
+
+#include "extractcallback.hpp"
+#include "bytespan.hpp"
+#include "fixedbufferextractcallback.hpp"
+
+namespace bit7z{
+
+class FixedBuffersExtractCallback final : public ExtractCallback {
+public:
+    FixedBuffersExtractCallback( const BitInputArchive& inputArchive, std::map< uint32_t, ByteSpan > buffers );
+
+    FixedBuffersExtractCallback( const FixedBuffersExtractCallback& ) = delete;
+
+    FixedBuffersExtractCallback( FixedBuffersExtractCallback&& ) = delete;
+
+    auto operator=( const FixedBuffersExtractCallback& ) -> FixedBuffersExtractCallback& = delete;
+
+    auto operator=( FixedBuffersExtractCallback&& ) -> FixedBuffersExtractCallback& = delete;
+
+    ~FixedBuffersExtractCallback() override = default;
+
+private:
+    std::map< uint32_t, ByteSpan > mBuffers;
+    std::map< uint32_t, FixedBufferExtractCallback > mBuffersCallbacks;
+
+    void releaseStream() override;
+
+    auto getOutStream( uint32_t index, ISequentialOutStream** outStream ) -> HRESULT override;
+};
+
+}
+
+
+
+#endif //FIXEDBUFFERSEXTRACTCALLBACK_HPP

--- a/src/internal/stringutil.hpp
+++ b/src/internal/stringutil.hpp
@@ -14,6 +14,7 @@
 #include "internal/fsutil.hpp"
 
 #include <algorithm>
+#include <string>
 namespace bit7z {
 
 #if defined( BIT7Z_USE_NATIVE_STRING ) && defined( _WIN32 )

--- a/tests/src/test_bitarchivereader.cpp
+++ b/tests/src/test_bitarchivereader.cpp
@@ -19,7 +19,6 @@
 #include <bit7z/bitarchivereader.hpp>
 #include <bit7z/bitexception.hpp>
 #include <bit7z/bitformat.hpp>
-#include <internal/stringutil.hpp>
 #include <internal/windows.hpp>
 
 // Needed by MSVC for defining the S_XXXX macros.
@@ -147,7 +146,7 @@ using stream_t = fs::ifstream;
 
 // Note: we cannot use value semantic and return the archive due to old GCC versions not supporting movable fstreams.
 void getInputArchive( const fs::path& path, tstring& archive ) {
-    archive = path_to_tstring( path );
+    archive = to_tstring( path.native() );
 }
 
 void getInputArchive( const fs::path& path, buffer_t& archive ) {
@@ -863,7 +862,7 @@ TEST_CASE( "BitArchiveReader: Reading an archive with a Unicode file name (bzip2
     const Bit7zLibrary lib{ test::sevenzip_lib_path() };
 
     fs::path arcFileName{ BIT7Z_NATIVE_STRING( "クラウド.jpg.bz2" ) };
-    const BitArchiveReader info( lib, path_to_tstring( arcFileName ), BitFormat::BZip2 );
+    const BitArchiveReader info( lib, to_tstring( arcFileName.native() ), BitFormat::BZip2 );
     REQUIRE_ITEM_UNICODE( info, "クラウド.jpg" );
 }
 #endif

--- a/tests/src/test_bitfileextractor.cpp
+++ b/tests/src/test_bitfileextractor.cpp
@@ -12,11 +12,117 @@
 
 #include <catch2/catch.hpp>
 
+#include <map>
+
+#include <vector>
+
+#include <random>
+
 #include "utils/shared_lib.hpp"
+
+#include <bit7z/bit7zlibrary.hpp>
 
 #include <bit7z/bitfileextractor.hpp>
 
+#include <bit7z/bitfilecompressor.hpp>
+
 using namespace bit7z;
+
+namespace {
+    auto createArchive(Bit7zLibrary& lib, const std::map< tstring, std::vector< byte_t > >& filenamesAndContents) -> std::vector< byte_t > {
+        BitFileCompressor compressor{lib, BitFormat::SevenZip};
+        compressor.setCompressionLevel(BitCompressionLevel::Fastest);
+        BitOutputArchive actualCompressor{compressor};
+
+        for (auto& filenameAndContent : filenamesAndContents) {
+            const std::string& filename = filenameAndContent.first;
+            const std::vector< byte_t >& content = filenameAndContent.second;
+            actualCompressor.addFile(content, filename);
+        }
+
+        std::vector< byte_t > buffer;
+        actualCompressor.compressTo(buffer);
+        return buffer;
+    }
+
+    std::vector<byte_t> generateBuffer(std::size_t length) {
+        std::random_device dev{};
+        std::default_random_engine engine{dev()};
+        std::uniform_int_distribution<unsigned> distribution{0, 255};
+
+        std::vector<byte_t> buffer;
+        buffer.reserve(length);
+        for (unsigned i=0; i < length; ++i) {
+            buffer.push_back(distribution(engine));
+        }
+
+        return buffer;
+    }
+
+    std::vector<byte_t> tstringToVector(tstring input) {
+        std::vector<byte_t> result;
+        result.reserve(input.size());
+        std::copy(input.begin(), input.end(), std::back_inserter(result));
+        return result;
+    }
+
+    struct PreExtractionData {
+        std::map<uint32_t, std::vector<byte_t>> buffers;
+        std::map<uint32_t, ByteSpan> bufferViews;
+        std::map<tstring, int32_t> fileNameToIndex;
+    };
+
+    PreExtractionData prepareExtractionData(BitInputArchive& archive) {
+        PreExtractionData result;
+        auto const numberOfItems = archive.itemsCount();
+        for (uint32_t index =0; index < numberOfItems; ++index) {
+            auto item = archive.itemAt(index);
+            if (item.isDir()) continue;
+            const auto neededSizeToExtract = item.size();
+            if (neededSizeToExtract == 0) continue;
+            result.buffers.emplace(index, std::vector<byte_t>(neededSizeToExtract));
+            result.bufferViews.emplace(index, ByteSpan{result.buffers[index].data(), result.buffers[index].size()});
+            result.fileNameToIndex.emplace(item.name(), index);
+        }
+
+        return result;
+    }
+}
+
+TEST_CASE( "BitFileExtractor", "extract to map of Bitspans" ) {
+    Bit7zLibrary lib{ test::sevenzip_lib_path() };
+
+    std::map< tstring, std::vector< byte_t > > files{
+        {tstring{"simple.txt"}, tstringToVector("simple file content in simple.txt")},
+        {tstring{"empty.bar"}, std::vector<byte_t>{}},
+        {tstring{"medium_file.buff"}, generateBuffer(5*1024*1024)},
+    };
+
+    auto archiveAsBuffer = createArchive(lib, files);
+
+    const BitFileExtractor extractor{lib, BitFormat::SevenZip};
+    BitInputArchive actualExtractor{extractor, archiveAsBuffer};
+
+    auto extractionData = prepareExtractionData(actualExtractor);
+
+    auto archiveContains = [&extractionData](const tstring& fileName) {
+        return extractionData.fileNameToIndex.find(fileName) != extractionData.fileNameToIndex.end();
+    };
+
+    REQUIRE(archiveContains("simple.txt"));
+    CHECK(!archiveContains("empty.bar"));
+    REQUIRE(archiveContains("medium_file.buff"));
+
+    actualExtractor.extractTo(extractionData.bufferViews);
+
+    auto extractedFileContent = [&extractionData](const tstring& fileName) {
+        const auto idx = extractionData.fileNameToIndex.at(fileName);
+        return extractionData.buffers.at(idx);
+    };
+
+    CHECK(extractedFileContent("simple.txt") == files["simple.txt"]);
+    CHECK(extractedFileContent("medium_file.buff") == files["medium_file.buff"]);
+}
 
 TEST_CASE( "BitFileExtractor: TODO", "[bitfileextractor]" ) {
     const Bit7zLibrary lib{ test::sevenzip_lib_path() };

--- a/tests/src/test_bitfileextractor.cpp
+++ b/tests/src/test_bitfileextractor.cpp
@@ -35,7 +35,7 @@ namespace {
         BitOutputArchive actualCompressor{ compressor };
 
         for ( const auto& filenameAndContent : filenamesAndContents ) {
-            const std::string& filename = filenameAndContent.first;
+            const tstring& filename = filenameAndContent.first;
             const buffer_t& content = filenameAndContent.second;
             actualCompressor.addFile( content, filename );
         }

--- a/tests/src/test_bitfileextractor.cpp
+++ b/tests/src/test_bitfileextractor.cpp
@@ -74,9 +74,7 @@ namespace {
 
     auto prepareExtractionData( const BitInputArchive& archive ) -> PreExtractionData {
         PreExtractionData result;
-        const auto numberOfItems = archive.itemsCount();
-        for ( uint32_t index =0; index < numberOfItems; ++index ) {
-            auto item = archive.itemAt( index );
+        for ( const auto& item : archive ) {
             if ( item.isDir() ) {
                 continue;
             }
@@ -84,6 +82,7 @@ namespace {
             if ( neededSizeToExtract == 0 ) {
                 continue;
             }
+            const auto index = item.index();
             result.buffers.emplace( index, buffer_t(neededSizeToExtract) );
             result.bufferViews.emplace( index, ByteSpan{ result.buffers[ index ].data(), result.buffers[ index ].size() } );
             result.fileNameToIndex.emplace( item.name(), index );

--- a/tests/src/test_bitfileextractor.cpp
+++ b/tests/src/test_bitfileextractor.cpp
@@ -29,99 +29,102 @@
 using namespace bit7z;
 
 namespace {
-    auto createArchive(Bit7zLibrary& lib, const std::map< tstring, std::vector< byte_t > >& filenamesAndContents) -> std::vector< byte_t > {
-        BitFileCompressor compressor{lib, BitFormat::SevenZip};
-        compressor.setCompressionLevel(BitCompressionLevel::Fastest);
-        BitOutputArchive actualCompressor{compressor};
+    auto createArchive( const Bit7zLibrary& lib, const std::map< tstring, buffer_t >& filenamesAndContents ) -> buffer_t {
+        BitFileCompressor compressor{ lib, BitFormat::SevenZip };
+        compressor.setCompressionLevel( BitCompressionLevel::Fastest );
+        BitOutputArchive actualCompressor{ compressor };
 
-        for (auto& filenameAndContent : filenamesAndContents) {
+        for ( const auto& filenameAndContent : filenamesAndContents ) {
             const std::string& filename = filenameAndContent.first;
-            const std::vector< byte_t >& content = filenameAndContent.second;
-            actualCompressor.addFile(content, filename);
+            const buffer_t& content = filenameAndContent.second;
+            actualCompressor.addFile( content, filename );
         }
 
-        std::vector< byte_t > buffer;
-        actualCompressor.compressTo(buffer);
+        buffer_t buffer;
+        actualCompressor.compressTo( buffer );
         return buffer;
     }
 
-    std::vector<byte_t> generateBuffer(std::size_t length) {
+    auto generateBuffer( std::size_t length ) -> buffer_t {
         std::random_device dev{};
-        std::default_random_engine engine{dev()};
-        std::uniform_int_distribution<unsigned> distribution{0, 255};
+        std::default_random_engine engine{ dev() };
+        std::uniform_int_distribution<unsigned> distribution{ 0, 255 };
 
-        std::vector<byte_t> buffer;
+        buffer_t buffer;
         buffer.reserve(length);
-        for (unsigned i=0; i < length; ++i) {
-            buffer.push_back(distribution(engine));
+        for ( unsigned i = 0; i < length; ++i) {
+            buffer.push_back( distribution( engine ) );
         }
 
         return buffer;
     }
 
-    std::vector<byte_t> tstringToVector(tstring input) {
-        std::vector<byte_t> result;
-        result.reserve(input.size());
-        std::copy(input.begin(), input.end(), std::back_inserter(result));
+    auto tstringToVector( const tstring& input ) -> buffer_t {
+        buffer_t result;
+        result.reserve( input.size() );
+        std::copy( input.begin(), input.end(), std::back_inserter( result ) );
         return result;
     }
 
     struct PreExtractionData {
-        std::map<uint32_t, std::vector<byte_t>> buffers;
-        std::map<uint32_t, ByteSpan> bufferViews;
-        std::map<tstring, int32_t> fileNameToIndex;
+        std::map< uint32_t, buffer_t > buffers;
+        std::map< uint32_t, ByteSpan > bufferViews;
+        std::map< tstring, uint32_t > fileNameToIndex;
     };
 
-    PreExtractionData prepareExtractionData(BitInputArchive& archive) {
+    auto prepareExtractionData( const BitInputArchive& archive ) -> PreExtractionData {
         PreExtractionData result;
-        auto const numberOfItems = archive.itemsCount();
-        for (uint32_t index =0; index < numberOfItems; ++index) {
-            auto item = archive.itemAt(index);
-            if (item.isDir()) continue;
+        const auto numberOfItems = archive.itemsCount();
+        for ( uint32_t index =0; index < numberOfItems; ++index ) {
+            auto item = archive.itemAt( index );
+            if ( item.isDir() ) {
+                continue;
+            }
             const auto neededSizeToExtract = item.size();
-            if (neededSizeToExtract == 0) continue;
-            result.buffers.emplace(index, std::vector<byte_t>(neededSizeToExtract));
-            result.bufferViews.emplace(index, ByteSpan{result.buffers[index].data(), result.buffers[index].size()});
-            result.fileNameToIndex.emplace(item.name(), index);
+            if ( neededSizeToExtract == 0 ) {
+                continue;
+            }
+            result.buffers.emplace( index, buffer_t(neededSizeToExtract) );
+            result.bufferViews.emplace( index, ByteSpan{ result.buffers[ index ].data(), result.buffers[ index ].size() } );
+            result.fileNameToIndex.emplace( item.name(), index );
         }
-
         return result;
     }
 }
 
-TEST_CASE( "BitFileExtractor", "extract to map of Bitspans" ) {
-    Bit7zLibrary lib{ test::sevenzip_lib_path() };
+TEST_CASE( "BitFileExtractor", "extract to map of ByteSpans" ) {
+    const Bit7zLibrary lib{ test::sevenzip_lib_path() };
 
-    std::map< tstring, std::vector< byte_t > > files{
-        {tstring{"simple.txt"}, tstringToVector("simple file content in simple.txt")},
-        {tstring{"empty.bar"}, std::vector<byte_t>{}},
-        {tstring{"medium_file.buff"}, generateBuffer(5*1024*1024)},
+    std::map< tstring, buffer_t > files{
+        { tstring{ "simple.txt" }, tstringToVector( "simple file content in simple.txt") },
+        { tstring{ "empty.bar" }, buffer_t{} },
+        { tstring{ "medium_file.buff" }, generateBuffer( 5*1024*1024 ) },
     };
 
-    auto archiveAsBuffer = createArchive(lib, files);
+    auto archiveAsBuffer = createArchive( lib, files );
 
-    const BitFileExtractor extractor{lib, BitFormat::SevenZip};
-    BitInputArchive actualExtractor{extractor, archiveAsBuffer};
+    const BitFileExtractor extractor{ lib, BitFormat::SevenZip };
+    BitInputArchive actualExtractor{ extractor, archiveAsBuffer };
 
-    auto extractionData = prepareExtractionData(actualExtractor);
+    auto extractionData = prepareExtractionData( actualExtractor );
 
-    auto archiveContains = [&extractionData](const tstring& fileName) {
-        return extractionData.fileNameToIndex.find(fileName) != extractionData.fileNameToIndex.end();
+    auto archiveContains = [ &extractionData ]( const tstring& fileName ) {
+        return extractionData.fileNameToIndex.find( fileName ) != extractionData.fileNameToIndex.end();
     };
 
-    REQUIRE(archiveContains("simple.txt"));
-    CHECK(!archiveContains("empty.bar"));
-    REQUIRE(archiveContains("medium_file.buff"));
+    REQUIRE( archiveContains( "simple.txt" ) );
+    CHECK( !archiveContains( "empty.bar" ) );
+    REQUIRE( archiveContains( "medium_file.buff" ) );
 
-    actualExtractor.extractTo(extractionData.bufferViews);
+    actualExtractor.extractTo( extractionData.bufferViews );
 
-    auto extractedFileContent = [&extractionData](const tstring& fileName) {
-        const auto idx = extractionData.fileNameToIndex.at(fileName);
-        return extractionData.buffers.at(idx);
+    auto extractedFileContent = [ &extractionData ]( const tstring& fileName ) {
+        const auto idx = extractionData.fileNameToIndex.at( fileName );
+        return extractionData.buffers.at( idx );
     };
 
-    CHECK(extractedFileContent("simple.txt") == files["simple.txt"]);
-    CHECK(extractedFileContent("medium_file.buff") == files["medium_file.buff"]);
+    CHECK( extractedFileContent( "simple.txt" ) == files[ "simple.txt" ] );
+    CHECK( extractedFileContent( "medium_file.buff" ) == files["medium_file.buff" ] );
 }
 
 TEST_CASE( "BitFileExtractor: TODO", "[bitfileextractor]" ) {

--- a/tests/src/test_bitfileextractor.cpp
+++ b/tests/src/test_bitfileextractor.cpp
@@ -59,7 +59,7 @@ namespace {
         return buffer;
     }
 
-    auto tstringToVector( const tstring& input ) -> buffer_t {
+    auto stringToVector( const std::string& input ) -> buffer_t {
         buffer_t result;
         result.reserve( input.size() );
         std::copy( input.begin(), input.end(), std::back_inserter( result ) );
@@ -95,16 +95,16 @@ namespace {
 TEST_CASE( "BitFileExtractor", "extract to map of ByteSpans" ) {
     const Bit7zLibrary lib{ test::sevenzip_lib_path() };
 
-    std::map< tstring, buffer_t > files{
-        { tstring{ "simple.txt" }, tstringToVector( "simple file content in simple.txt") },
-        { tstring{ "empty.bar" }, buffer_t{} },
-        { tstring{ "medium_file.buff" }, generateBuffer( 5*1024*1024 ) },
+    const std::map< tstring, buffer_t > files{
+        { BIT7Z_STRING( "simple.txt" ), stringToVector( "simple file content in simple.txt") },
+        { BIT7Z_STRING( "empty.bar" ), buffer_t{} },
+        { BIT7Z_STRING( "medium_file.buff" ), generateBuffer( 5 * 1024 * 1024 ) },
     };
 
     auto archiveAsBuffer = createArchive( lib, files );
 
     const BitFileExtractor extractor{ lib, BitFormat::SevenZip };
-    BitInputArchive actualExtractor{ extractor, archiveAsBuffer };
+    const BitInputArchive actualExtractor{ extractor, archiveAsBuffer };
 
     auto extractionData = prepareExtractionData( actualExtractor );
 
@@ -112,9 +112,14 @@ TEST_CASE( "BitFileExtractor", "extract to map of ByteSpans" ) {
         return extractionData.fileNameToIndex.find( fileName ) != extractionData.fileNameToIndex.end();
     };
 
-    REQUIRE( archiveContains( "simple.txt" ) );
-    CHECK( !archiveContains( "empty.bar" ) );
-    REQUIRE( archiveContains( "medium_file.buff" ) );
+    const tstring simpleFileName = BIT7Z_STRING( "simple.txt" );
+    REQUIRE( archiveContains( simpleFileName ) );
+
+    const tstring emptyFileName = BIT7Z_STRING( "empty.bar" );
+    REQUIRE_FALSE( archiveContains( emptyFileName ) );
+
+    const tstring mediumFileName = BIT7Z_STRING( "medium_file.buff" );
+    REQUIRE( archiveContains( mediumFileName ) );
 
     actualExtractor.extractTo( extractionData.bufferViews );
 
@@ -123,8 +128,8 @@ TEST_CASE( "BitFileExtractor", "extract to map of ByteSpans" ) {
         return extractionData.buffers.at( idx );
     };
 
-    CHECK( extractedFileContent( "simple.txt" ) == files[ "simple.txt" ] );
-    CHECK( extractedFileContent( "medium_file.buff" ) == files["medium_file.buff" ] );
+    REQUIRE( extractedFileContent( BIT7Z_STRING( "simple.txt" ) ) == files.at( simpleFileName ) );
+    REQUIRE( extractedFileContent( BIT7Z_STRING( "medium_file.buff" ) ) == files.at( mediumFileName ) );
 }
 
 TEST_CASE( "BitFileExtractor: TODO", "[bitfileextractor]" ) {


### PR DESCRIPTION
Adding a possibility to perform extraction to a map of indexes and view of buffers.

## Description

Introduced new type:

`BitSpan`, which is very simplified version of `std::span` .

which is then used in functions:
```
extractTo(std::map<uint32_t /*index*/, BitSpan /* buffer view*/> bufferViews);
extractTo(BitSpan bufferView, uint32_t index);
```

## Motivation and Context

Problem: It is inefficient to perform extraction of archive item by item
Problem: It is not possible to perform extraction of all items in archive in single pass to preallocated buffers

Two above problems lead to implementation of this change. It is beneficial to be able to perform extraction to preallocated buffer
(as is already possible to do this with single item using existing API). In my case I need ability to extract items to memory mapped files. And in some cases doing this element by element is very inefficient.

## How Has This Been Tested?

Tested only with added unit test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
<!-- TODO: - [ ] I have read the **CONTRIBUTING** document. -->