### PR TITLE
Responsive archive operations with progress-based cancelation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ set( HEADERS
      src/internal/operationcategory.hpp
      src/internal/operationresult.hpp
      src/internal/processeditem.hpp
+     src/internal/progressoutstream.hpp
      src/internal/renameditem.hpp
      src/internal/stdinputitem.hpp
      src/internal/streamextractcallback.hpp
@@ -154,6 +155,7 @@ set( SOURCES
      src/internal/operationcategory.cpp
      src/internal/operationresult.cpp
      src/internal/processeditem.cpp
+     src/internal/progressoutstream.cpp
      src/internal/renameditem.cpp
      src/internal/stdinputitem.cpp
      src/internal/streamextractcallback.cpp

--- a/include/bit7z/bitabstractarchivehandler.hpp
+++ b/include/bit7z/bitabstractarchivehandler.hpp
@@ -26,8 +26,8 @@ class BitInFormat;
 using TotalCallback = std::function< void( uint64_t ) >;
 
 /**
- * @brief A std::function whose argument is the currently processed size of the ongoing operation and returns
- *        true or false whether the operation must continue or not.
+ * @brief A std::function whose argument is the currently processed input size of the ongoing operation and
+ *        returns true or false depending on whether the operation must continue or not.
  */
 using ProgressCallback = std::function< bool( uint64_t ) >;
 
@@ -228,7 +228,8 @@ class BitAbstractArchiveHandler {
     protected:
         explicit BitAbstractArchiveHandler( const Bit7zLibrary& lib,
                                             tstring password = {},
-                                            OverwriteMode overwriteMode = OverwriteMode::None );
+                                            OverwriteMode overwriteMode = OverwriteMode::None,
+                                            ProgressCallback progressCallback = nullptr );
 
     private:
         const Bit7zLibrary& mLibrary;

--- a/include/bit7z/bitabstractarchiveopener.hpp
+++ b/include/bit7z/bitabstractarchiveopener.hpp
@@ -48,7 +48,8 @@ class BitAbstractArchiveOpener : public BitAbstractArchiveHandler {
     protected:
         BitAbstractArchiveOpener( const Bit7zLibrary& lib,
                                   const BitInFormat& format,
-                                  const tstring& password = {} );
+                                  const tstring& password = {},
+                                  const ProgressCallback& progressCallback = nullptr );
 
     private:
         const BitInFormat& mFormat;

--- a/src/bitabstractarchivehandler.cpp
+++ b/src/bitabstractarchivehandler.cpp
@@ -16,11 +16,13 @@ using namespace bit7z;
 
 BitAbstractArchiveHandler::BitAbstractArchiveHandler( const Bit7zLibrary& lib,
                                                       tstring password,
-                                                      OverwriteMode overwriteMode )
+                                                      OverwriteMode overwriteMode,
+                                                      ProgressCallback progressCallback )
     : mLibrary{ lib },
       mPassword{ std::move( password ) },
       mRetainDirectories{ true },
-      mOverwriteMode{ overwriteMode } {}
+      mOverwriteMode{ overwriteMode },
+      mProgressCallback{ std::move( progressCallback ) } {}
 
 auto BitAbstractArchiveHandler::library() const noexcept -> const Bit7zLibrary& {
     return mLibrary;

--- a/src/bitabstractarchiveopener.cpp
+++ b/src/bitabstractarchiveopener.cpp
@@ -16,8 +16,10 @@ using namespace bit7z;
 
 BitAbstractArchiveOpener::BitAbstractArchiveOpener( const Bit7zLibrary& lib,
                                                     const BitInFormat& format,
-                                                    const tstring& password )
-    : BitAbstractArchiveHandler{ lib, password, OverwriteMode::Overwrite }, mFormat{ format } {}
+                                                    const tstring& password,
+                                                    const ProgressCallback& progressCallback )
+    : BitAbstractArchiveHandler{ lib, password, OverwriteMode::Overwrite, progressCallback },
+      mFormat{ format } {}
 
 auto BitAbstractArchiveOpener::format() const noexcept -> const BitInFormat& {
     return mFormat;

--- a/src/internal/bufferextractcallback.cpp
+++ b/src/internal/bufferextractcallback.cpp
@@ -13,6 +13,7 @@
 #include "bitexception.hpp"
 #include "internal/bufferextractcallback.hpp"
 #include "internal/cbufferoutstream.hpp"
+#include "internal/progressoutstream.hpp"
 #include "internal/fs.hpp"
 #include "internal/stringutil.hpp"
 #include "internal/util.hpp"
@@ -73,9 +74,12 @@ auto BufferExtractCallback::getOutStream( uint32_t index, ISequentialOutStream**
         }
     }
 
-    auto outStreamLoc = bit7z::make_com< CBufferOutStream, ISequentialOutStream >( outBuffer );
-    mOutMemStream = outStreamLoc;
-    *outStream = outStreamLoc.Detach();
+    auto finalStream = bit7z::make_com< CBufferOutStream, IOutStream >( outBuffer );
+    if ( mHandler.progressCallback() ) {
+        finalStream = bit7z::make_com< ProgressOutStream, IOutStream >( finalStream, mHandler.progressCallback() );
+    }
+    mOutMemStream = finalStream;
+    *outStream = finalStream.Detach();
     return S_OK;
 }
 

--- a/src/internal/bufferextractcallback.hpp
+++ b/src/internal/bufferextractcallback.hpp
@@ -37,7 +37,18 @@ class BufferExtractCallback final : public ExtractCallback {
 
     private:
         map< tstring, vector< byte_t > >& mBuffersMap;
-        CMyComPtr< ISequentialOutStream > mOutMemStream;
+        
+        CMyComPtr< IOutStream > mOutMemStream;  // was ISequentialOutStream
+
+        /* Changing ISequentialOutStream to IOutStream aligns the member with the new stream type created in getOutStream. 
+           The output buffer is now wrapped in CBufferOutStream and optionally ProgressOutStream, 
+           both of which expose the full IOutStream interface; assigning that IOutStream pointer to a CMyComPtr<ISequentialOutStream> 
+           would require unsafe conversions and wouldn’t compile. Using IOutStream lets the progress-enabled stream be stored and later 
+           released correctly while still returning an ISequentialOutStream** to satisfy the 7‑Zip callback contract 
+
+           Same goes for FixedBufferExtractCallback 
+
+           */
 
         void releaseStream() override;
 

--- a/src/internal/fixedbufferextractcallback.hpp
+++ b/src/internal/fixedbufferextractcallback.hpp
@@ -32,7 +32,7 @@ class FixedBufferExtractCallback final : public ExtractCallback {
     private:
         byte_t* mBuffer;
         size_t mSize;
-        CMyComPtr< ISequentialOutStream > mOutMemStream;
+        CMyComPtr< IOutStream > mOutMemStream;
 
         void releaseStream() override;
 

--- a/src/internal/opencallback.hpp
+++ b/src/internal/opencallback.hpp
@@ -44,6 +44,9 @@ class OpenCallback final : public IArchiveOpenCallback,
         BIT7Z_NODISCARD
         auto passwordWasAsked() const -> bool;
 
+        BIT7Z_NODISCARD
+        auto operationWasCanceled() const -> bool;
+
         // IArchiveOpenCallback
         BIT7Z_STDMETHOD( SetTotal, const UInt64* files, const UInt64* bytes );
 
@@ -68,6 +71,7 @@ class OpenCallback final : public IArchiveOpenCallback,
         std::wstring mSubArchiveName;
         fs::path mArchivePath;
         bool mPasswordWasAsked;
+        bool mOperationCanceled;
 };
 
 }  // namespace bit7z

--- a/src/internal/operationcategory.cpp
+++ b/src/internal/operationcategory.cpp
@@ -47,6 +47,8 @@ auto OperationCategory::message( int errorValue ) const -> std::string {
             return "Reached an unexpected end of data.";
         case OperationResult::UnsupportedMethod:
             return "Unsupported method.";
+        case OperationResult::Aborted:
+            return "Operation aborted.";
         default:
             return "Unknown error.";
     }
@@ -70,6 +72,8 @@ auto OperationCategory::default_error_condition( int errorValue ) const noexcept
         case OperationResult::CRCErrorEncrypted:
         case OperationResult::OpenErrorEncrypted:
             return std::make_error_condition( std::errc::operation_not_permitted );
+        case OperationResult::Aborted:
+            return std::make_error_condition( std::errc::operation_canceled );
         default:
             return error_category::default_error_condition( errorValue );
     }

--- a/src/internal/operationresult.hpp
+++ b/src/internal/operationresult.hpp
@@ -36,6 +36,7 @@ enum struct OperationResult {
     CRCErrorEncrypted = ( 2 * NOperationResult::kWrongPassword ) + 1,
     OpenErrorEncrypted = ( 2 * NOperationResult::kWrongPassword ) + 2,
     EmptyPassword = ( 2 * NOperationResult::kWrongPassword ) + 3,
+    Aborted = ( 2 * NOperationResult::kWrongPassword ) + 4,
 };
 
 auto make_error_code( OperationResult error ) -> std::error_code;

--- a/src/internal/progressoutstream.cpp
+++ b/src/internal/progressoutstream.cpp
@@ -1,0 +1,44 @@
+// This is an open source non-commercial project. Dear PVS-Studio, please check it.
+// PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
+
+/*
+ * bit7z - A C++ static library to interface with the 7-zip shared libraries.
+ * Copyright (c) 2014-2023 Riccardo Ostani - All Rights Reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "internal/progressoutstream.hpp"
+
+namespace bit7z {
+
+ProgressOutStream::ProgressOutStream( IOutStream* stream, ProgressCallback callback )
+    : mStream( stream ), mCallback( std::move( callback ) ), mProcessed( 0 ) {}
+
+COM_DECLSPEC_NOTHROW
+STDMETHODIMP ProgressOutStream::Write( const void* data, UInt32 size, UInt32* processedSize ) noexcept {
+    const HRESULT res = mStream->Write( data, size, processedSize );
+    if ( res != S_OK ) {
+        return res;
+    }
+    mProcessed += ( processedSize != nullptr ? *processedSize : size );
+    if ( mCallback && !mCallback( mProcessed ) ) {
+        return E_ABORT;
+    }
+    return res;
+}
+
+COM_DECLSPEC_NOTHROW
+STDMETHODIMP ProgressOutStream::Seek( Int64 offset, UInt32 seekOrigin, UInt64* newPosition ) noexcept {
+    return mStream->Seek( offset, seekOrigin, newPosition );
+}
+
+COM_DECLSPEC_NOTHROW
+STDMETHODIMP ProgressOutStream::SetSize( UInt64 newSize ) noexcept {
+    return mStream->SetSize( newSize );
+}
+
+} // namespace bit7z
+

--- a/src/internal/progressoutstream.hpp
+++ b/src/internal/progressoutstream.hpp
@@ -1,0 +1,49 @@
+/*
+ * bit7z - A C++ static library to interface with the 7-zip shared libraries.
+ * Copyright (c) 2014-2023 Riccardo Ostani - All Rights Reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef PROGRESSOUTSTREAM_HPP
+#define PROGRESSOUTSTREAM_HPP
+
+#include "bitabstractarchivehandler.hpp"
+#include "internal/com.hpp"
+#include "internal/guids.hpp"
+#include "internal/macros.hpp"
+
+#include <7zip/IStream.h>
+
+namespace bit7z {
+
+class ProgressOutStream final : public IOutStream, public CMyUnknownImp {
+    public:
+        ProgressOutStream( IOutStream* stream, ProgressCallback callback );
+
+        ProgressOutStream( const ProgressOutStream& ) = delete;
+        ProgressOutStream( ProgressOutStream&& ) = delete;
+        auto operator=( const ProgressOutStream& ) -> ProgressOutStream& = delete;
+        auto operator=( ProgressOutStream&& ) -> ProgressOutStream& = delete;
+        MY_UNKNOWN_DESTRUCTOR( ~ProgressOutStream() ) = default;
+
+        // IOutStream
+        BIT7Z_STDMETHOD( Write, const void* data, UInt32 size, UInt32* processedSize );
+        BIT7Z_STDMETHOD( Seek, Int64 offset, UInt32 seekOrigin, UInt64* newPosition );
+        BIT7Z_STDMETHOD( SetSize, UInt64 newSize );
+
+        // NOLINTNEXTLINE(modernize-use-noexcept, modernize-use-trailing-return-type, readability-identifier-length)
+        MY_UNKNOWN_IMP1( IOutStream )
+
+    private:
+        CMyComPtr< IOutStream > mStream;
+        ProgressCallback mCallback;
+        uint64_t mProcessed;
+};
+
+} // namespace bit7z
+
+#endif // PROGRESSOUTSTREAM_HPP
+

--- a/src/internal/streamextractcallback.cpp
+++ b/src/internal/streamextractcallback.cpp
@@ -13,6 +13,7 @@
 #include "internal/cstdoutstream.hpp"
 #include "internal/streamextractcallback.hpp"
 #include "internal/util.hpp"
+#include "internal/progressoutstream.hpp"
 
 using namespace std;
 using namespace NWindows;
@@ -48,10 +49,15 @@ auto StreamExtractCallback::getOutStream( uint32_t index, ISequentialOutStream**
         mHandler.fileCallback()( fullPath );
     }
 
-    auto outStreamLoc = bit7z::make_com< CStdOutStream, IOutStream >( mOutputStream );
-    mStdOutStream = outStreamLoc;
-    *outStream = outStreamLoc.Detach();
+    auto finalStream = bit7z::make_com< CStdOutStream, IOutStream >( mOutputStream );
+    if ( mHandler.progressCallback() ) {
+        finalStream = bit7z::make_com< ProgressOutStream, IOutStream >( finalStream, mHandler.progressCallback() );
+    }
+
+    mStdOutStream = finalStream;
+    *outStream = finalStream.Detach();
     return S_OK;
 }
 
 } // namespace bit7z
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Reuses existing progress callback to make the library more responsive when opening an archive with containing tens of thousands of entries—previously the library remained unresponsive until enumeration finished. This required some of existing classes (BitAbstractArchiveHandler, BitAbstractArchiveOpener, BitArchiveReader ...) constructors to accept ProgressCallback as the last OPTIONAL parameter
- Reuses existing progress callback to solve freezes during extraction of very large files by allowing progress-driven cancelation. New ProgressOutStream class that that acts as a thin wrapper around any IOutStream, tracking how many bytes have been written and invoking a user-supplied ProgressCallback after each write.

## How Has This Been Tested?
- Builts fine with CMake
- Opened large archives while observing progress updates and confirming the ability to cancel early.
- Extracted multi‑gigabyte files and verified the application stayed responsive and could abort mid-extraction.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.