### PR TITLE
Extraction to preallocated buffers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,7 @@ set( HEADERS
      src/internal/optional.hpp
      src/internal/processeditem.hpp
      src/internal/rawdataextractcallback.hpp
+     src/internal/rawdataextractcallbackwid.hpp
      src/internal/sequentialextractcallback.hpp
      src/internal/streamextractcallback.hpp
      src/internal/streamutil.hpp
@@ -167,6 +168,7 @@ set( SOURCES
      src/internal/operationresult.cpp
      src/internal/processeditem.cpp
      src/internal/rawdataextractcallback.cpp
+     src/internal/rawdataextractcallbackwid.cpp
      src/internal/sequentialextractcallback.cpp
      src/internal/streamextractcallback.cpp
      src/internal/stringutil.cpp

--- a/include/bit7z/bitabstractarchivehandler.hpp
+++ b/include/bit7z/bitabstractarchivehandler.hpp
@@ -79,6 +79,32 @@ enum struct FilterResult : std::uint8_t {
  */
 using FilterCallback = std::function< FilterResult( const BitArchiveItem& ) >;
 
+enum struct FileAwarenessOption {
+    WithFileName,
+    WithoutFileName
+};
+
+template<FileAwarenessOption FileAwarenessOpt>
+struct FileAwareExtraction;
+
+template<>
+struct FileAwareExtraction<FileAwarenessOption::WithFileName>{
+    virtual bool write( const byte_t* dataStart, std::size_t dataSize) = 0;
+    virtual void onNewFile(std::uint32_t index, std::string fileName) = 0;
+
+private:
+    ~FileAwareExtraction() = default;
+};
+
+template<>
+struct FileAwareExtraction<FileAwarenessOption::WithoutFileName>{
+    virtual bool write( const byte_t* dataStart, std::size_t dataSize) = 0;
+    virtual void onNewFile(std::uint32_t index) = 0;
+
+private:
+    ~FileAwareExtraction() = default;
+};
+
 /**
  * @brief Enumeration representing how a handler should deal when an output file already exists.
  */

--- a/include/bit7z/bitabstractarchivehandler.hpp
+++ b/include/bit7z/bitabstractarchivehandler.hpp
@@ -79,29 +79,12 @@ enum struct FilterResult : std::uint8_t {
  */
 using FilterCallback = std::function< FilterResult( const BitArchiveItem& ) >;
 
-enum struct FileAwarenessOption {
-    WithFileName,
-    WithoutFileName
-};
 
-template<FileAwarenessOption FileAwarenessOpt>
-struct FileAwareExtraction;
-
-template<>
-struct FileAwareExtraction<FileAwarenessOption::WithFileName>{
+struct FileAwareExtraction{
     virtual bool write( const byte_t* dataStart, std::size_t dataSize) = 0;
-    virtual void onNewFile(std::uint32_t index, std::string fileName) = 0;
+    virtual void onNewFile(std::uint32_t index, tstring fileName) = 0;
 
-private:
-    ~FileAwareExtraction() = default;
-};
-
-template<>
-struct FileAwareExtraction<FileAwarenessOption::WithoutFileName>{
-    virtual bool write( const byte_t* dataStart, std::size_t dataSize) = 0;
-    virtual void onNewFile(std::uint32_t index) = 0;
-
-private:
+protected:
     ~FileAwareExtraction() = default;
 };
 

--- a/include/bit7z/bitextractor.hpp
+++ b/include/bit7z/bitextractor.hpp
@@ -212,7 +212,7 @@ class BitExtractor final : public BitAbstractArchiveOpener {
         */
         void extract( Input inArchive, const std::map< std::uint32_t, BitView< byte_t > > & indicesWithBuffers ) const {
             BitInputArchive inputArchive( *this, inArchive );
-            struct ExtractionCallback : FileAwareExtraction<FileAwarenessOption::WithoutFileName> {
+            struct ExtractionCallback : FileAwareExtraction {
 
                 bool write(const byte_t *dataStart, std::size_t dataSize) override {
                     auto buffer = indicesWithBuffers.at(currentIdx);
@@ -227,7 +227,7 @@ class BitExtractor final : public BitAbstractArchiveOpener {
                     return true;
                 }
 
-                void onNewFile(std::uint32_t index) override {
+                void onNewFile(std::uint32_t index, std::string /*fileName*/) override {
                     currentIdx = index;
                     lastWritePosition = 0;
                 }
@@ -269,43 +269,7 @@ class BitExtractor final : public BitAbstractArchiveOpener {
         * @param callback  a function providing the extracted raw data to the user.
         * @param indices   (optional) the indices of the files in the archive that must be extracted.
         */
-        void extractTo( Input inArchive, FileAwareExtraction<FileAwarenessOption::WithFileName>& callback, BitIndicesView indices = {} ) {
-            const BitInputArchive inputArchive( *this, inArchive );
-            auto previousFileCallback = fileCallback();
-            tstring currentFile;
-            setFileCallback([&](const tstring& file) {
-                currentFile = file;
-                if (previousFileCallback)
-                    previousFileCallback(file);
-            });
-
-            struct FileAwareExtractionImpl : FileAwareExtraction<FileAwarenessOption::WithoutFileName> {
-                bool write(const byte_t *dataStart, std::size_t dataSize) override {
-                    return actualCallback.write(dataStart, dataSize);
-                }
-
-                void onNewFile(std::uint32_t index) override {
-                    actualCallback.onNewFile(index, currentFile);
-                }
-
-                FileAwareExtraction<FileAwarenessOption::WithFileName>& actualCallback;
-                tstring& currentFile;
-            } callbackImpl {callback, currentFile};
-
-            inputArchive.extractTo( callbackImpl , indices );
-            setFileCallback(previousFileCallback);
-        }
-
-        /**
-        * @brief Extracts the raw content of the archive to the given extraction interface.
-        *
-        * @note You can set a FileCallback to check the file being extracted.
-        *
-        * @param inArchive the input archive to be extracted.
-        * @param callback  a function providing the extracted raw data to the user.
-        * @param indices   (optional) the indices of the files in the archive that must be extracted.
-        */
-        void extractTo( Input inArchive, FileAwareExtraction<FileAwarenessOption::WithoutFileName>& callback, BitIndicesView indices = {} ) const {
+        void extractTo( Input inArchive, FileAwareExtraction& callback, BitIndicesView indices = {} ) const {
             const BitInputArchive inputArchive( *this, inArchive );
             inputArchive.extractTo( callback , indices );
         }

--- a/include/bit7z/bitextractor.hpp
+++ b/include/bit7z/bitextractor.hpp
@@ -203,6 +203,19 @@ class BitExtractor final : public BitAbstractArchiveOpener {
         }
 
         /**
+        * @brief Extracts the content of the given archive into a provided map of memory buffers, where the keys are
+        * indices of the files (inside the archive) to be extracted, and the values are preallocated buffers to
+        * which extraction is to be performed.
+        *
+        * @param inArchive             the input archive to be extracted.
+        * @param indicesWithBuffers    the map with indices of files and preallocated buffers.
+        */
+        void extract( Input inArchive, const std::map< uint32_t, BitView< byte_t > > & indicesWithBuffers ) const {
+            BitInputArchive inputArchive( *this, inArchive );
+            inputArchive.extractTo( indicesWithBuffers );
+        }
+
+        /**
          * @brief Extracts the raw content of the archive to the given callback.
          *
          * @note You can set a FileCallback to check the file being extracted.
@@ -214,6 +227,56 @@ class BitExtractor final : public BitAbstractArchiveOpener {
         void extractTo( Input inArchive, RawDataCallback callback, BitIndicesView indices = {} ) const {
             const BitInputArchive inputArchive( *this, inArchive );
             inputArchive.extractTo( std::move( callback ), indices );
+        }
+
+        /**
+        * @brief Extracts the raw content of the archive to the given extraction interface.
+        *
+        * @note You can set a FileCallback to check the file being extracted.
+        *
+        * @param inArchive the input archive to be extracted.
+        * @param callback  a function providing the extracted raw data to the user.
+        * @param indices   (optional) the indices of the files in the archive that must be extracted.
+        */
+        void extractTo( Input inArchive, FileAwareExtraction<FileAwarenessOption::WithFileName>& callback, BitIndicesView indices = {} ) {
+            const BitInputArchive inputArchive( *this, inArchive );
+            auto previousFileCallback = fileCallback();
+            tstring currentFile;
+            setFileCallback([&](const tstring& file) {
+                currentFile = file;
+                if (previousFileCallback)
+                    previousFileCallback(file);
+            });
+
+            struct FileAwareExtractionImpl : FileAwareExtraction<FileAwarenessOption::WithoutFileName> {
+                bool write(const byte_t *dataStart, std::size_t dataSize) override {
+                    return actualCallback.write(dataStart, dataSize);
+                }
+
+                void onNewFile(std::uint32_t index) override {
+                    actualCallback.onNewFile(index, currentFile);
+                }
+
+                FileAwareExtraction<FileAwarenessOption::WithFileName>& actualCallback;
+                tstring& currentFile;
+            } callbackImpl {callback, currentFile};
+
+            inputArchive.extractTo( callbackImpl , indices );
+            setFileCallback(previousFileCallback);
+        }
+
+        /**
+        * @brief Extracts the raw content of the archive to the given extraction interface.
+        *
+        * @note You can set a FileCallback to check the file being extracted.
+        *
+        * @param inArchive the input archive to be extracted.
+        * @param callback  a function providing the extracted raw data to the user.
+        * @param indices   (optional) the indices of the files in the archive that must be extracted.
+        */
+        void extractTo( Input inArchive, FileAwareExtraction<FileAwarenessOption::WithoutFileName>& callback, BitIndicesView indices = {} ) const {
+            const BitInputArchive inputArchive( *this, inArchive );
+            inputArchive.extractTo( callback , indices );
         }
 
         /**

--- a/include/bit7z/bitextractor.hpp
+++ b/include/bit7z/bitextractor.hpp
@@ -210,9 +210,40 @@ class BitExtractor final : public BitAbstractArchiveOpener {
         * @param inArchive             the input archive to be extracted.
         * @param indicesWithBuffers    the map with indices of files and preallocated buffers.
         */
-        void extract( Input inArchive, const std::map< uint32_t, BitView< byte_t > > & indicesWithBuffers ) const {
+        void extract( Input inArchive, const std::map< std::uint32_t, BitView< byte_t > > & indicesWithBuffers ) const {
             BitInputArchive inputArchive( *this, inArchive );
-            inputArchive.extractTo( indicesWithBuffers );
+            struct ExtractionCallback : FileAwareExtraction<FileAwarenessOption::WithoutFileName> {
+
+                bool write(const byte_t *dataStart, std::size_t dataSize) override {
+                    auto buffer = indicesWithBuffers.at(currentIdx);
+                    auto bufferStart = buffer.data();
+                    //todo handle too small buffers
+                    if (buffer.size() < lastWritePosition + dataSize) {
+                        return false;
+                    }
+                    std::copy_n(dataStart, dataSize, bufferStart+lastWritePosition);
+                    lastWritePosition += dataSize;
+
+                    return true;
+                }
+
+                void onNewFile(std::uint32_t index) override {
+                    currentIdx = index;
+                    lastWritePosition = 0;
+                }
+
+                const std::map< uint32_t, BitView< byte_t > > & indicesWithBuffers;
+                std::uint32_t currentIdx = -1;
+                std::size_t lastWritePosition=0;
+            } callback{indicesWithBuffers};
+
+            std::vector<std::uint32_t> indices;
+            indices.resize(indicesWithBuffers.size());
+            for (const auto& [key, value] : indicesWithBuffers) {
+                indices.push_back(key);
+            }
+
+            extractTo(inArchive, callback, indices);
         }
 
         /**

--- a/include/bit7z/bitindicesview.hpp
+++ b/include/bit7z/bitindicesview.hpp
@@ -21,6 +21,11 @@
 
 namespace bit7z {
 
+using IndicesVector = std::vector< std::uint32_t >;
+
+template< std::size_t N >
+using IndicesArray = std::array< std::uint32_t, N >;
+
 using BitIndicesView = BitView< const std::uint32_t >;
 
 } // namespace bit7z

--- a/include/bit7z/bitindicesview.hpp
+++ b/include/bit7z/bitindicesview.hpp
@@ -11,6 +11,7 @@
 #define BITINDICESVIEW_HPP
 
 #include "bitdefines.hpp"
+#include "bitview.hpp"
 
 #include <array>
 #include <cstddef>
@@ -19,97 +20,9 @@
 #include <vector>
 
 namespace bit7z {
-using IndicesVector = std::vector< std::uint32_t >;
 
-template< std::size_t N >
-using IndicesArray = std::array< std::uint32_t, N >;
+using BitIndicesView = BitView< const std::uint32_t >;
 
-// NOLINTBEGIN(*-explicit-conversions, *-avoid-c-arrays, *-pro-bounds-pointer-arithmetic)
-class BitIndicesView final {
-    public:
-        // BitIndicesView is basically a C++20's std::span< const std::uint32_t >.
-        // Note: still not using C++14's traits style as bit7z's public API must be written in C++11.
-        using element_type = const std::uint32_t; // T in std::span<T>.
-        using value_type = std::remove_cv< element_type >::type;
-        using size_type = std::uint32_t; // 7-Zip uses 32-bits for the size of the indices array.
-        using difference_type = std::ptrdiff_t;
-        using pointer = element_type*;
-        using const_pointer = const element_type*;
-        using reference = element_type&;
-        using const_reference = const element_type&;
-        using iterator = pointer;
-        using const_iterator = const_pointer;
-        using reverse_iterator = std::reverse_iterator< iterator >;
-        using const_reverse_iterator = std::reverse_iterator< const_iterator >;
-
-        constexpr BitIndicesView() noexcept : mIndices{ nullptr }, mSize{ 0 } {}
-
-        /* implicit */ constexpr BitIndicesView( const_reference index ) noexcept
-            : mIndices{ &index }, mSize{ 1 } {}
-
-        // Note: this constructor can't be constexpr until C++20 due to std::vector's methods.
-        /* implicit */ BitIndicesView( const IndicesVector& indices ) noexcept
-            : BitIndicesView{ indices.data(), indices.size() } {}
-
-        template< std::size_t N >
-        /* implicit */ constexpr BitIndicesView( element_type (&indices)[ N ] ) noexcept
-            : BitIndicesView{ static_cast< const_pointer >( indices ), N } {}
-
-        template< typename U,
-                  std::size_t N,
-                  typename = typename std::enable_if< std::is_convertible<
-                      U(*)[ ], element_type(*)[ ] >::value >::type >
-        /* implicit */ constexpr BitIndicesView( const std::array< U, N >& indices ) noexcept
-            : BitIndicesView{ indices.data(), indices.size() } {}
-
-        BitIndicesView( std::initializer_list< value_type > indices ) noexcept
-            : BitIndicesView{ indices.begin(), indices.size() } {}
-
-        BIT7Z_NODISCARD
-        constexpr auto data() const noexcept -> const_pointer {
-            return mIndices;
-        }
-
-        BIT7Z_NODISCARD
-        constexpr auto size() const noexcept -> size_type {
-            return mSize;
-        }
-
-        BIT7Z_NODISCARD
-        constexpr auto begin() const noexcept -> iterator {
-            return cbegin();
-        }
-
-        BIT7Z_NODISCARD
-        constexpr auto end() const noexcept -> iterator {
-            return cend();
-        }
-
-        BIT7Z_NODISCARD
-        constexpr auto cbegin() const noexcept -> const_iterator {
-            return mIndices;
-        }
-
-        BIT7Z_NODISCARD
-        constexpr auto cend() const noexcept -> const_iterator {
-            return mIndices + mSize;
-        }
-
-        BIT7Z_NODISCARD
-        constexpr auto empty() const noexcept -> bool {
-            return mIndices == nullptr;
-        }
-
-    private:
-        const_pointer mIndices;
-        size_type mSize;
-
-        constexpr BitIndicesView( const_pointer indices, std::size_t size ) noexcept
-            : mIndices{ size == 0 ? nullptr : indices },
-              mSize{ static_cast< size_type >( size ) } {}
-};
-
-// NOLINTEND(*-explicit-conversions, *-avoid-c-arrays, *-pro-bounds-pointer-arithmetic)
 } // namespace bit7z
 
 #endif //BITINDICESVIEW_HPP

--- a/include/bit7z/bitinputarchive.hpp
+++ b/include/bit7z/bitinputarchive.hpp
@@ -219,13 +219,12 @@ class BitInputArchive {
        /**
        * @brief Extracts the raw content of the archive to the given extraction interface.
        *
-       * @note You can set a FileCallback to check the file being extracted.
        *
        * @param inArchive the input archive to be extracted.
        * @param callback  a function providing the extracted raw data to the user.
        * @param indices   (optional) the indices of the files in the archive that must be extracted.
        */
-        void extractTo( FileAwareExtraction<FileAwarenessOption::WithoutFileName>& callback, BitIndicesView indices = {} ) const;
+        void extractTo( FileAwareExtraction& callback, BitIndicesView indices = {} ) const;
 
         /**
          * @brief Extracts the specified items to the chosen directory.

--- a/include/bit7z/bitinputarchive.hpp
+++ b/include/bit7z/bitinputarchive.hpp
@@ -216,6 +216,17 @@ class BitInputArchive {
             extractTo( outDir, indices );
         }
 
+       /**
+       * @brief Extracts the raw content of the archive to the given extraction interface.
+       *
+       * @note You can set a FileCallback to check the file being extracted.
+       *
+       * @param inArchive the input archive to be extracted.
+       * @param callback  a function providing the extracted raw data to the user.
+       * @param indices   (optional) the indices of the files in the archive that must be extracted.
+       */
+        void extractTo( FileAwareExtraction<FileAwarenessOption::WithoutFileName>& callback, BitIndicesView indices = {} ) const;
+
         /**
          * @brief Extracts the specified items to the chosen directory.
          *

--- a/include/bit7z/bitview.hpp
+++ b/include/bit7z/bitview.hpp
@@ -43,7 +43,7 @@ public:
         : mStart{ &index }, mSize{ 1 } {}
 
     // Note: this constructor can't be constexpr until C++20 due to std::vector's methods.
-    /* implicit */ BitView( const std::vector< T >& indices ) noexcept
+    /* implicit */ BitView( const std::vector< value_type >& indices ) noexcept
         : BitView{ indices.data(), indices.size() } {}
 
     template< std::size_t N >

--- a/include/bit7z/bitview.hpp
+++ b/include/bit7z/bitview.hpp
@@ -1,0 +1,110 @@
+/*
+ * bit7z - A C++ static library to interface with the 7-zip shared libraries.
+ * Copyright (c) 2014-2025 Riccardo Ostani - All Rights Reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef BITVIEW_HPP
+#define BITVIEW_HPP
+
+#include "bitdefines.hpp"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <vector>
+
+namespace bit7z {
+
+// NOLINTBEGIN(*-explicit-conversions, *-avoid-c-arrays, *-pro-bounds-pointer-arithmetic)
+template <typename T>
+class BitView {
+public:
+    using element_type = T; // T in std::span<T>.
+    using value_type = typename std::remove_cv< element_type >::type;
+    using size_type = std::uint32_t; // 7-Zip uses 32-bits for the size of the indices array.
+    using difference_type = std::ptrdiff_t;
+    using pointer = element_type*;
+    using const_pointer = const element_type*;
+    using reference = element_type&;
+    using const_reference = const element_type&;
+    using iterator = pointer;
+    using const_iterator = const_pointer;
+    using reverse_iterator = std::reverse_iterator< iterator >;
+    using const_reverse_iterator = std::reverse_iterator< const_iterator >;
+
+    constexpr BitView() noexcept : mStart{ nullptr }, mSize{ 0 } {}
+
+    /* implicit */ constexpr BitView( const_reference index ) noexcept
+        : mStart{ &index }, mSize{ 1 } {}
+
+    // Note: this constructor can't be constexpr until C++20 due to std::vector's methods.
+    /* implicit */ BitView( const std::vector< T >& indices ) noexcept
+        : BitView{ indices.data(), indices.size() } {}
+
+    template< std::size_t N >
+    /* implicit */ constexpr BitView( element_type (&indices)[ N ] ) noexcept
+        : BitView{ static_cast< const_pointer >( indices ), N } {}
+
+    template< typename U,
+              std::size_t N,
+              typename = typename std::enable_if< std::is_convertible<
+                  U(*)[ ], element_type(*)[ ] >::value >::type >
+    /* implicit */ constexpr BitView( const std::array< U, N >& indices ) noexcept
+        : BitView{ indices.data(), indices.size() } {}
+
+    BitView( std::initializer_list< value_type > indices ) noexcept
+        : BitView{ indices.begin(), indices.size() } {}
+
+    BIT7Z_NODISCARD
+    constexpr auto data() const noexcept -> const_pointer {
+        return mStart;
+    }
+
+    BIT7Z_NODISCARD
+    constexpr auto size() const noexcept -> size_type {
+        return mSize;
+    }
+
+    BIT7Z_NODISCARD
+    constexpr auto begin() const noexcept -> iterator {
+        return cbegin();
+    }
+
+    BIT7Z_NODISCARD
+    constexpr auto end() const noexcept -> iterator {
+        return cend();
+    }
+
+    BIT7Z_NODISCARD
+    constexpr auto cbegin() const noexcept -> const_iterator {
+        return mStart;
+    }
+
+    BIT7Z_NODISCARD
+    constexpr auto cend() const noexcept -> const_iterator {
+        return mStart + mSize;
+    }
+
+    BIT7Z_NODISCARD
+    constexpr auto empty() const noexcept -> bool {
+        return mStart == nullptr;
+    }
+
+private:
+    const_pointer mStart;
+    size_type mSize;
+
+    constexpr BitView( const_pointer bufferStart, std::size_t size ) noexcept
+        : mStart{ size == 0 ? nullptr : bufferStart },
+          mSize{ static_cast< size_type >( size ) } {}
+};
+// NOLINTEND(*-explicit-conversions, *-avoid-c-arrays, *-pro-bounds-pointer-arithmetic)
+
+} // namespace bit7z
+
+#endif //BITVIEW_HPP

--- a/src/bitinputarchive.cpp
+++ b/src/bitinputarchive.cpp
@@ -51,6 +51,8 @@
 #include <utility>
 #include <vector>
 
+#include "internal/rawdataextractcallbackwid.hpp"
+
 using namespace NWindows;
 using namespace NArchive;
 
@@ -563,6 +565,21 @@ void BitInputArchive::extractTo( BufferCallback callback, BitIndicesView indices
     const auto extractCallback = bit7z::make_com< BufferExtractCallback, ExtractCallback >(
         *this,
         std::move( callback )
+    );
+    extractArchive( extractCallback, NAskMode::kExtract, indices );
+}
+
+void BitInputArchive::extractTo(FileAwareExtraction<FileAwarenessOption::WithoutFileName> &callback,
+        BitIndicesView indices) const {
+    const auto invalidIndex = findInvalidIndex( indices );
+    if ( invalidIndex != indices.cend() ) {
+        throw BitException( "Cannot extract item at the index " + std::to_string( *invalidIndex ),
+                            make_error_code( BitError::InvalidIndex ) );
+    }
+
+    const auto extractCallback = bit7z::make_com< RawDataExtractCallbackWid, ExtractCallback >(
+        *this,
+        callback
     );
     extractArchive( extractCallback, NAskMode::kExtract, indices );
 }

--- a/src/bitinputarchive.cpp
+++ b/src/bitinputarchive.cpp
@@ -569,8 +569,8 @@ void BitInputArchive::extractTo( BufferCallback callback, BitIndicesView indices
     extractArchive( extractCallback, NAskMode::kExtract, indices );
 }
 
-void BitInputArchive::extractTo(FileAwareExtraction<FileAwarenessOption::WithoutFileName> &callback,
-        BitIndicesView indices) const {
+
+void BitInputArchive::extractTo(FileAwareExtraction &callback, BitIndicesView indices) const {
     const auto invalidIndex = findInvalidIndex( indices );
     if ( invalidIndex != indices.cend() ) {
         throw BitException( "Cannot extract item at the index " + std::to_string( *invalidIndex ),

--- a/src/internal/rawdataextractcallbackwid.cpp
+++ b/src/internal/rawdataextractcallbackwid.cpp
@@ -1,0 +1,71 @@
+// This is an open source non-commercial project. Dear PVS-Studio, please check it.
+// PVS-Studio Static Code Analyzer for C, C++ and C#: http://www.viva64.com
+
+/*
+ * bit7z - A C++ static library to interface with the 7-zip shared libraries.
+ * Copyright (c) 2014-2024 Riccardo Ostani - All Rights Reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#include "rawdataextractcallbackwid.hpp"
+
+#include "internal/rawdataextractcallback.hpp"
+
+#include "bitinputarchive.hpp"
+#include "bitpropvariant.hpp"
+#include "internal/crawoutstream.hpp"
+#include "internal/extractcallback.hpp"
+#include "internal/util.hpp"
+
+#include <cstdint>
+#include <ostream>
+#include <utility>
+
+using namespace NWindows;
+
+namespace bit7z {
+
+RawDataExtractCallbackWid::RawDataExtractCallbackWid( const BitInputArchive& inputArchive, CallbackType& callback )
+    : ExtractCallback( inputArchive ),
+      mCallback( callback ) {}
+
+void RawDataExtractCallbackWid::releaseStream() {
+    mCallbackStream.Release();
+}
+
+auto RawDataExtractCallbackWid::getOutStream( uint32_t index, ISequentialOutStream** outStream ) -> HRESULT {
+    if ( isItemFolder( index ) ) {
+        return S_OK;
+    }
+
+    if ( mHandler.fileCallback() ) {
+        // Get Name
+        const BitPropVariant prop = itemProperty( index, BitProperty::Path );
+        tstring fullPath;
+
+        if ( prop.isEmpty() ) {
+            fullPath = kEmptyFileAlias;
+        } else if ( prop.isString() ) {
+            fullPath = prop.getString();
+        } else {
+            return E_FAIL;
+        }
+
+        mHandler.fileCallback()( fullPath );
+    }
+
+    RawDataCallback callback = [this](const byte_t* data_start, std::size_t data_size) -> bool {
+        return mCallback.write(data_start, data_size);
+    };
+
+    mCallback.onNewFile(index);
+    auto outStreamLoc = bit7z::make_com< CRawOutStream, ISequentialOutStream >( std::move(callback) );
+    mCallbackStream = outStreamLoc;
+    *outStream = outStreamLoc.Detach();
+    return S_OK;
+}
+
+} // namespace bit7z

--- a/src/internal/rawdataextractcallbackwid.cpp
+++ b/src/internal/rawdataextractcallbackwid.cpp
@@ -41,19 +41,18 @@ auto RawDataExtractCallbackWid::getOutStream( uint32_t index, ISequentialOutStre
         return S_OK;
     }
 
-    if ( mHandler.fileCallback() ) {
-        // Get Name
-        const BitPropVariant prop = itemProperty( index, BitProperty::Path );
-        tstring fullPath;
+    const BitPropVariant prop = itemProperty( index, BitProperty::Path );
+    tstring fullPath;
 
-        if ( prop.isEmpty() ) {
-            fullPath = kEmptyFileAlias;
-        } else if ( prop.isString() ) {
-            fullPath = prop.getString();
-        } else {
-            return E_FAIL;
-        }
+    if ( prop.isEmpty() ) {
+        fullPath = kEmptyFileAlias;
+    } else if ( prop.isString() ) {
+        fullPath = prop.getString();
+    } else {
+        return E_FAIL;
+    }
 
+    if (mHandler.fileCallback()) {
         mHandler.fileCallback()( fullPath );
     }
 
@@ -61,7 +60,7 @@ auto RawDataExtractCallbackWid::getOutStream( uint32_t index, ISequentialOutStre
         return mCallback.write(data_start, data_size);
     };
 
-    mCallback.onNewFile(index);
+    mCallback.onNewFile(index, std::move(fullPath));
     auto outStreamLoc = bit7z::make_com< CRawOutStream, ISequentialOutStream >( std::move(callback) );
     mCallbackStream = outStreamLoc;
     *outStream = outStreamLoc.Detach();

--- a/src/internal/rawdataextractcallbackwid.hpp
+++ b/src/internal/rawdataextractcallbackwid.hpp
@@ -1,0 +1,49 @@
+/*
+ * bit7z - A C++ static library to interface with the 7-zip shared libraries.
+ * Copyright (c) 2014-2024 Riccardo Ostani - All Rights Reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#ifndef RAWDATAEXTRACTCALLBACKWID_HPP
+#define RAWDATAEXTRACTCALLBACKWID_HPP
+
+#include "bitabstractarchivehandler.hpp"
+#include "internal/extractcallback.hpp"
+
+#include <cstdint>
+
+namespace bit7z {
+
+class BitInputArchive;
+
+
+class RawDataExtractCallbackWid final : public ExtractCallback {
+    public:
+        using CallbackType = FileAwareExtraction<FileAwarenessOption::WithoutFileName>;
+        RawDataExtractCallbackWid( const BitInputArchive& inputArchive, CallbackType& callback );
+
+        RawDataExtractCallbackWid( const RawDataExtractCallbackWid& ) = delete;
+
+        RawDataExtractCallbackWid( RawDataExtractCallbackWid&& ) = delete;
+
+        auto operator=( const RawDataExtractCallbackWid& ) -> RawDataExtractCallbackWid& = delete;
+
+        auto operator=( RawDataExtractCallbackWid&& ) -> RawDataExtractCallbackWid& = delete;
+
+        ~RawDataExtractCallbackWid() override = default;
+
+    private:
+        CallbackType& mCallback;
+        CMyComPtr< ISequentialOutStream > mCallbackStream;
+
+        void releaseStream() override;
+
+        auto getOutStream( std::uint32_t index, ISequentialOutStream** outStream ) -> HRESULT override;
+};
+
+}  // namespace bit7z
+
+#endif // RAWDATAEXTRACTCALLBACKWID_HPP

--- a/src/internal/rawdataextractcallbackwid.hpp
+++ b/src/internal/rawdataextractcallbackwid.hpp
@@ -22,7 +22,7 @@ class BitInputArchive;
 
 class RawDataExtractCallbackWid final : public ExtractCallback {
     public:
-        using CallbackType = FileAwareExtraction<FileAwarenessOption::WithoutFileName>;
+        using CallbackType = FileAwareExtraction;
         RawDataExtractCallbackWid( const BitInputArchive& inputArchive, CallbackType& callback );
 
         RawDataExtractCallbackWid( const RawDataExtractCallbackWid& ) = delete;

--- a/tests/src/test_bitinputarchive.cpp
+++ b/tests/src/test_bitinputarchive.cpp
@@ -32,6 +32,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <iostream>
 #include <numeric>
 #include <random>
 #include <sstream>
@@ -2028,5 +2029,66 @@ TEMPLATE_TEST_CASE( "BitInputArchive: Extracting a non-existing folder from an a
 
         REQUIRE_THROWS( info.extractFolderTo( testOutDir, folderPath ) );
         REQUIRE( fs::is_empty( testOutDir.path() ) );
+    }
+}
+
+TEMPLATE_TEST_CASE( "BitInputArchive: Extract to callback",
+                    "[bitinputarchive]", tstring, buffer_t, stream_t ) {
+    const TestDirectory testDir{ fs::path{ test_archives_dir } / "extraction" / "multiple_files" };
+
+#ifdef BIT7Z_BUILD_FOR_P7ZIP
+    const auto testArchive = GENERATE( as< TestInputFormat >(),
+                                       TestInputFormat{ "7z", BitFormat::SevenZip },
+                                       TestInputFormat{ "iso", BitFormat::Iso },
+                                       TestInputFormat{ "tar", BitFormat::Tar },
+                                       TestInputFormat{ "wim", BitFormat::Wim },
+                                       TestInputFormat{ "zip", BitFormat::Zip } );
+#else
+    const auto testArchive = GENERATE( as< TestInputFormat >(),
+                                       TestInputFormat{ "7z", BitFormat::SevenZip },
+                                       // TestInputFormat{ "iso", BitFormat::Iso }, iso format has reverse ids of the elements? todo
+                                       TestInputFormat{ "rar", BitFormat::Rar5 },
+                                       TestInputFormat{ "tar", BitFormat::Tar },
+                                       TestInputFormat{ "wim", BitFormat::Wim },
+                                       TestInputFormat{ "zip", BitFormat::Zip } );
+#endif
+
+    DYNAMIC_SECTION( "Archive format: " << testArchive.extension ) {
+        const fs::path arcFileName = fs::path{ "multiple_files" }.concat( "." + testArchive.extension );
+
+        TestType inputArchive{};
+        getInputArchive( arcFileName, inputArchive );
+        const Bit7zLibrary lib{ test::sevenzip_lib_path() };
+        BitArchiveReader info( lib, inputArchive, testArchive.format );
+
+        struct Extractor final : FileAwareExtraction {
+            bool write(const byte_t *dataStart, std::size_t dataSize) override {
+                totalSize += dataSize;
+                auto& currentCrc = idToCrc.at(currentIdx);
+                currentCrc = crc32( dataStart, dataSize, currentCrc );
+                return true;
+            }
+
+            void onNewFile(std::uint32_t const index, tstring fileName) override {
+                idToCrc[index] = {};
+                idToPath[index] = std::move(fileName);
+                currentIdx = index;
+            }
+
+            std::size_t totalSize{};
+            std::map<std::uint32_t, std::uint32_t> idToCrc;
+            std::map<std::uint32_t, tstring> idToPath;
+            std::size_t currentIdx{0};
+        } extractor;
+
+        info.extractTo(extractor);
+
+        auto const& expectations = multiple_files_content();
+        CHECK(expectations.size == extractor.totalSize);
+        CHECK(expectations.fileCount == extractor.idToCrc.size());
+        for (std::size_t idx=0; idx < expectations.items.size(); ++idx) {
+            CHECK(expectations.items[idx].fileInfo.crc32 == extractor.idToCrc[idx]);
+            CHECK(expectations.items[idx].fileInfo.name == extractor.idToPath[idx]);
+        }
     }
 }


### PR DESCRIPTION
This is a sketch of an idea to extract data to preallocated buffers.

The idea stays the same as previously - add API to extract archive to preallocated buffers.

When implementing that functionality with RawDataExtractCallback I realised, that I am missing information
about when the new file starts and when it ends. 

Hence idea of yet new API appeared.

Once the idea is approved I will:
- cleanup the code
- add more thorough testing
- add size hint to the FileAwareExtraction interface
- unify RawDataExtractCallback and RawDataExtractCallbackWid

## Description

One solution I could go with, but didn't choose one:
- in the implementation save user provided callback for fileCallback
- add own callback for fileCallback that would call user provided fileCallback + that will inform rawCallback, that file with new id is being written to (this also seems simplistic, as fileCallback only has filePath information without id)
- use RawCallback implementation to perform extraction
- on extraction finished restore user provided fileCallback

I added another option:
- add one new user API to extract using FileAwareExtraction interface, that was introduced
```c++
struct FileAwareExtraction{
    virtual bool write( const byte_t* dataStart, std::size_t dataSize) = 0;
    virtual void onNewFile(std::uint32_t index, tstring fileName) = 0; // note: in final implementation I also want to add size hint for the file - if size information is available it will be provided to the user - this way user can preallocate buffers as needed.

protected:
    ~FileAwareExtraction() = default;
};
```
- the interface consists of write callback to actually store extracted data and onNewFile callback for information when extraction of new file takes place (with id and fileName)
- it uses slightly modified copy of RawDataExtractCallback (will unify if idea is approved)
- the cllback calls interface functions when necessary

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The change allows user to simply define their own extraction strategy:
- by providing preallocated buffers (e.g. 

## How Has This Been Tested?
very initial testing using unit tests. More thorough tests will be added when idea is accepted.
unit tests were launched locally on windows 11 machine

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
<!-- TODO: - [ ] I have read the **CONTRIBUTING** document. -->